### PR TITLE
chore(ci): add least-privilege permissions: contents: read to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Summary
- Add explicit least-privilege permissions to CI workflow to satisfy Code Scanning alert actions/missing-workflow-permissions.

Change
- Inserted a top-level permissions block in [.github/workflows/ci.yml](.github/workflows/ci.yml:1):

```yaml
permissions:
  contents: read
```

Rationale
- Code Scanning alert #1 (actions/missing-workflow-permissions) flagged missing explicit permissions on CI. This change follows GitHub’s least-privilege guidance to set read-only by default.

Acceptance
- CodeQL re-runs on this PR; the Code Scanning alert should close after merge.
- Required checks remain green (lint, typecheck, unit, build, e2e; and Code scanning results / CodeQL).

Notes
- Branch: chore/ci-permissions-read-only
- File changed: [.github/workflows/ci.yml](.github/workflows/ci.yml:1)

## Summary by Sourcery

CI:
- Grant read-only contents permission in CI workflow