### PR TITLE
chore(ci): pin GitHub Actions by commit SHA across workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: npm
@@ -35,7 +35,7 @@ jobs:
 
       # Cache Playwright browsers for faster E2E
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
@@ -46,7 +46,7 @@ jobs:
       - run: npm run e2e
 
       - if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: playwright-report

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: npm
@@ -31,22 +31,22 @@ jobs:
         run: npm ci
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
         with:
           languages: javascript-typescript
 
       # For JS/TS, autobuild attempts a best-effort build (or no-op if not needed).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
 
       - name: Perform CodeQL Analysis
         id: analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
         continue-on-error: true
 
       - name: Upload CodeQL SARIF as artifact (when code scanning disabled)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: codeql-sarif
           path: results/**/*.sarif

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         with:
-          args: '--no-git --redact --report-format sarif --report-path gitleaks.sarif'
+          args: "--no-git --redact --report-format sarif --report-path gitleaks.sarif"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -24,20 +24,20 @@ jobs:
       security-events: write
     steps:
       - name: Checkout full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         with:
-          args: "--no-git --redact --report-format sarif --report-path gitleaks.sarif"
+          args: '--no-git --redact --report-format sarif --report-path gitleaks.sarif'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF to code scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
         with:
           sarif_file: gitleaks.sarif
           category: gitleaks
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload Gitleaks SARIF artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: gitleaks-sarif
           path: gitleaks.sarif

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,10 +12,10 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Apply labels based on changed files
-        uses: actions/labeler@v5
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -16,8 +16,8 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: micnncim/action-label-syncer@v1
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1
         with:
           manifest: .github/labels.yml
           prune: true


### PR DESCRIPTION
Supply-chain hardening: pin third-party GitHub Actions to immutable commit SHAs; no functional logic changes.

Pinned:
- CodeQL workflow [.github/workflows/codeql.yml](.github/workflows/codeql.yml:1)
  - actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
  - actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
  - github/codeql-action/{init,autobuild,analyze,upload-sarif}@3c3833e0f8c1c83d449a7478aa59c036a9165498
  - actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

- Gitleaks workflow [.github/workflows/gitleaks.yml](.github/workflows/gitleaks.yml:1)
  - actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
  - gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
  - github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498
  - actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

- Auto label PRs [.github/workflows/labeler.yml](.github/workflows/labeler.yml:1)
  - actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
  - actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9

- Sync labels [.github/workflows/labels-sync.yml](.github/workflows/labels-sync.yml:1)
  - actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
  - micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c

CI [.github/workflows/ci.yml](.github/workflows/ci.yml:1) remains least-privileged and already pinned previously.

Verification plan:
- Ensure all workflows run on this PR (CodeQL, Gitleaks, Labeler, Label Sync; artifacts upload intact).
- After merge, CodeQL on main should supersede the legacy dynamic analysis alert and keep code scanning clean.

## Summary by Sourcery

CI:
- Pin CodeQL, Gitleaks, CI, labeler, and label-sync workflows to specific commit SHAs instead of floating versions