### PR TITLE
chore(ci): add actionlint workflow and finalize CI TODOs

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,38 @@
+name: Actionlint
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**/*.yml'
+      - '.github/workflows/**/*.yaml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**/*.yml'
+      - '.github/workflows/**/*.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: Lint GitHub workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint via reviewdog
+        uses: reviewdog/action-actionlint@e37e2ca68a70112d21e135229272da28ce2d0d5a # v1
+        with:
+          reporter: github-pr-check
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          fail_on_error: 'true'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'astro.config.mjs'
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
     paths:
@@ -21,6 +22,7 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'astro.config.mjs'
+      - '.github/workflows/**'
   schedule:
     - cron: '33 1 * * 1' # Weekly (Mon 01:33 UTC)
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,24 @@ name: CodeQL
 on:
   push:
     branches: [main]
+    paths:
+      - '**/*.js'
+      - '**/*.ts'
+      - '**/*.tsx'
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'astro.config.mjs'
   pull_request:
     branches: [main]
+    paths:
+      - '**/*.js'
+      - '**/*.ts'
+      - '**/*.tsx'
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'astro.config.mjs'
   schedule:
     - cron: '33 1 * * 1' # Weekly (Mon 01:33 UTC)
 
@@ -13,6 +29,10 @@ permissions:
   contents: read
   security-events: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: CodeQL Analyze (JS/TS)
@@ -20,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -12,6 +12,10 @@ permissions:
   pull-requests: read
   security-events: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gitleaks:
     name: Gitleaks scan
@@ -27,11 +31,12 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         with:
-          args: "--no-git --redact --report-format sarif --report-path gitleaks.sarif"
+          args: '--no-git --redact --report-format sarif --report-path gitleaks.sarif'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,11 +8,17 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   label:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
 
       - name: Apply labels based on changed files
         uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -12,11 +12,17 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
       - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1
         with:
           manifest: .github/labels.yml


### PR DESCRIPTION
Summary

Introduce actionlint to lint GitHub workflows and finalize CI hardening items (permissions, concurrency, path filters, and checkout persist-credentials hygiene). All actions remain pinned to immutable commit SHAs per repository policy.

Changes

1) New workflow: [Actionlint](.github/workflows/actionlint.yml)
- Triggers:
  - pull_request with path filters:
    - '.github/workflows/**/*.yml'
    - '.github/workflows/**/*.yaml'
  - push on main with same path filters
  - workflow_dispatch
- Least-privilege permissions:
  - contents: read
  - checks: write (needed for reviewdog GitHub Checks)
- Concurrency:
  - group: ${{ github.workflow }}-${{ github.ref }}
  - cancel-in-progress: true
- Steps:
  - Checkout pinned and hardened with persist-credentials: false:
    - actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
  - reviewdog/action-actionlint pinned:
    - reviewdog/action-actionlint@e37e2ca68a70112d21e135229272da28ce2d0d5a
  - Reporter:
    - reporter: github-pr-check
    - fail_on_error: 'true'

2) CI hardening across existing workflows
- [CodeQL](.github/workflows/codeql.yml)
  - Add concurrency block (same pattern as above)
  - Add path filters to limit runs to relevant files (JS/TS, src, build config): '**/*.js', '**/*.ts', '**/*.tsx', 'src/**', 'package.json', 'package-lock.json', 'astro.config.mjs'
  - Checkout hardened with persist-credentials: false
  - Actions pinned (already present, verified):
    - actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
    - actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
    - github/codeql-action/{init,autobuild,analyze}@3c3833e0f8c1c83d449a7478aa59c036a9165498
    - actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
- [Gitleaks](.github/workflows/gitleaks.yml)
  - Add concurrency block
  - Checkout hardened with persist-credentials: false (kept fetch-depth: 0)
  - Actions pinned (verified):
    - actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
    - gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
    - github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498
    - actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
- [Auto label PRs](.github/workflows/labeler.yml)
  - Add concurrency block
  - Checkout hardened with persist-credentials: false
  - Actions pinned (verified):
    - actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
    - actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9
- [Sync labels](.github/workflows/labels-sync.yml)
  - Add concurrency block
  - Checkout hardened with persist-credentials: false
  - Actions pinned (verified):
    - actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
    - micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c

Security and reliability rationale
- Enforce least-privilege GITHUB_TOKEN scopes per workflow
- Eliminate tag drift by pinning to immutable SHAs
- Prevent credentials from being written into git remotes during CI by using persist-credentials: false
- Avoid redundant runs and reduce cost via concurrency and path filters

Notable SHAs (verified)
- actions/checkout: 08eba0b27e820071cde6df949e0beb9ba4906955
- actions/setup-node: 49933ea5288caeca8642d1e84afbd3f7d6820020
- actions/cache: 0400d5f644dc74513175e3cd8d07132dd4860809
- actions/upload-artifact: ea165f8d65b6e75b540449e92b4886f43607fa02
- github/codeql-action (init/autobuild/analyze/upload-sarif): 3c3833e0f8c1c83d449a7478aa59c036a9165498
- gitleaks/gitleaks-action: ff98106e4c7b2bc287b24eaf42907196329070c7
- actions/labeler: 8558fd74291d67161a8a78ce36a881fa63b766a9
- micnncim/action-label-syncer: 3abd5ab72fda571e69fffd97bd4e0033dd5f495c
- reviewdog/action-actionlint: e37e2ca68a70112d21e135229272da28ce2d0d5a

Follow-ups
- Let this PR run Actionlint; fix any reported issues in the same branch until green.
- After merge, ensure a fresh CodeQL run on main to supersede any residual alerts.

## Summary by Sourcery

Introduce an Actionlint workflow for linting GitHub workflow files and finalize CI hardening by enforcing least-privilege permissions, concurrency controls, path filters, checkout hygiene, and immutable action SHAs across all workflows

New Features:
- Add Actionlint workflow to lint GitHub workflow files on pull requests and pushes

Enhancements:
- Enforce least-privilege GITHUB_TOKEN permissions and add concurrency groups to all existing workflows
- Restrict workflow runs with path filters in CodeQL and apply checkout hygiene (persist-credentials: false) across workflows