### PR TITLE
build(railway): add start command and production server; docs: add Railway runbook

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm run start

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run start
+web: node server.mjs

--- a/README.md
+++ b/README.md
@@ -267,3 +267,36 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for project conventions, CSP posture, t
 ## Changelog
 
 See [CHANGELOG.md](./CHANGELOG.md) for release notes.
+
+## Production deployment (Railway)
+
+This project supports a production deployment on Railway using an explicit start command and a minimal static server.
+
+- Start command and server
+  - `npm run start` runs `node server.mjs`, binding to `0.0.0.0:$PORT`.
+  - Health probe: `GET /health` returns `200` with body `ok`.
+- Nixpacks and Node
+  - Node 20 is pinned via `engines` in `package.json` and `nixpacks.toml` (`nodejs_20`).
+  - Phases:
+    - Install: `npm ci`
+    - Build: `npm run build`
+- How to deploy
+  - CI: Push to `main` or merge a PR into `main` to trigger a Railway build and deploy.
+  - CLI (optional):
+    ```bash
+    railway login
+    railway link    # once per local clone
+    railway status
+    railway logs -f
+    ```
+- Required environment variables
+  - `NODE_ENV=production` (set in Railway environment)
+  - No secrets are committed; manage secrets via Railway project variables.
+- Local production run (parity)
+  ```bash
+  npm ci
+  npm run build
+  PORT=3000 npm run start
+  ```
+- Rollback
+  - Revert the offending commit and push to `main`, or redeploy a previous successful deployment from the Railway UI.

--- a/README.md
+++ b/README.md
@@ -270,33 +270,71 @@ See [CHANGELOG.md](./CHANGELOG.md) for release notes.
 
 ## Production deployment (Railway)
 
-This project supports a production deployment on Railway using an explicit start command and a minimal static server.
+Production previews and deployments run a hardened static server implemented in [server.mjs](server.mjs:1). The server streams files, validates canonical real paths (symlink‑safe), restricts SPA fallback to HTML‑eligible requests, and applies strict caching and headers.
 
-- Start command and server
-  - `npm run start` runs `node server.mjs`, binding to `0.0.0.0:$PORT`.
-  - Health probe: `GET /health` returns `200` with body `ok`.
-- Nixpacks and Node
-  - Node 20 is pinned via `engines` in `package.json` and `nixpacks.toml` (`nodejs_20`).
-  - Phases:
-    - Install: `npm ci`
-    - Build: `npm run build`
-- How to deploy
-  - CI: Push to `main` or merge a PR into `main` to trigger a Railway build and deploy.
-  - CLI (optional):
-    ```bash
-    railway login
-    railway link    # once per local clone
-    railway status
-    railway logs -f
-    ```
-- Required environment variables
-  - `NODE_ENV=production` (set in Railway environment)
-  - No secrets are committed; manage secrets via Railway project variables.
-- Local production run (parity)
+- Prereqs and environment
+  - Node 20 is enforced via `"engines": { "node": ">=20 <21" }` in [package.json](package.json:1) and `nodejs_20` in [nixpacks.toml](nixpacks.toml:1).
+  - Ensure `NODE_ENV=production` in your Railway environment.
+
+- Start command detection
+  - Package script: `"start": "node server.mjs"` in [package.json](package.json:1).
+  - Procfile: `web: node server.mjs` in [Procfile](Procfile:1).
+  - Nixpacks: `[start] cmd = "npm run start"` in [nixpacks.toml](nixpacks.toml:1).
+  - Railway will detect any of the above; all point to the same explicit entry.
+
+- Health
+  - `GET /health` returns `200` with body `ok`.
+  - Configure Railway health probe path to `/health`.
+
+- Caching and headers
+  - Fingerprinted assets (filenames containing `.[0-9a-f]{8,}.`) → `Cache-Control: public, max-age=31536000, immutable`.
+  - Other static assets → `Cache-Control: public, max-age=3600`.
+  - HTML (including fallbacks) → `Cache-Control: no-cache`.
+  - `X-Content-Type-Options: nosniff` and `Accept-Ranges: none` are set on responses.
+  - `Last-Modified` is set from the file’s mtime; `Content-Type` inferred by extension.
+
+- SPA fallback rules
+  - If the request is for a static asset extension and the file is missing → 404 (no index.html fallback).
+  - Fallback to `index.html` only when:
+    - The path is extensionless OR the `Accept` header prefers `text/html`.
+    - Path traversal protection still applies; the server validates real paths remain inside the build output.
+
+- Security and path validation
+  - All file responses validate canonical real paths remain within the canonical `dist` realpath to prevent traversal via symlinks.
+  - Directory listings and error stack traces are not exposed.
+
+- Graceful shutdown
+  - The server tracks sockets. On SIGTERM/SIGINT it:
+    1. Stops accepting new connections.
+    2. Attempts to end idle sockets.
+    3. Waits up to 10s for active connections to close, then force‑destroys remaining sockets.
+    4. Exits with code 0.
+
+- Server logs
+  - Minimal structured request logs are emitted: `method=GET path=/... status=200 ms=... bytes=...`.
+  - View logs in Railway: `railway logs -f` or via the project’s Logs UI.
+
+- Local production validation
   ```bash
   npm ci
   npm run build
   PORT=3000 npm run start
+  # In another shell:
+  curl -i http://localhost:3000/
+  curl -i http://localhost:3000/health
+  # Known asset (adjust path to a real built asset):
+  curl -I http://localhost:3000/assets/*.css
+  # Unknown asset → 404 (no SPA fallback):
+  curl -I http://localhost:3000/unknown-asset.png
+  # Extensionless route → HTML fallback (200):
+  curl -i http://localhost:3000/terms/xss
+  # Traversal attempt → blocked (400 or 404), must not escape dist:
+  curl -i "http://localhost:3000/%2e%2e/%2e%2e/package.json"
   ```
-- Rollback
-  - Revert the offending commit and push to `main`, or redeploy a previous successful deployment from the Railway UI.
+
+- Deploy and rollback
+  - Push to `main` (or merge PR) to trigger Railway build and deploy.
+  - Rollback by reverting the offending commit or redeploying a prior successful build from the Railway UI.
+
+Notes
+- PR preview builds on Railway should now be green with the explicit `npm run start → node server.mjs` and Procfile `web: node server.mjs`.

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,11 @@
+[phases.setup]
+nixPkgs = ["nodejs_20"]
+
+[phases.install]
+command = "npm ci"
+
+[phases.build]
+command = "npm run build"
+
+[start]
+cmd = "npm run start"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "synac",
   "type": "module",
   "version": "0.0.1",
+  "engines": {
+    "node": ">=20 <21"
+  },
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview --port 4321 --host",
+    "start": "node server.mjs",
     "astro": "astro",
     "typecheck": "astro check",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx,.astro,.mdx",

--- a/server.mjs
+++ b/server.mjs
@@ -70,7 +70,7 @@ const ASSET_EXTS = new Set([
   '.wasm',
 ]);
 
-const HASH_RE = /\.[0-9a-f]{8,}\./i;
+const HASH_RE = /\.[A-Za-z0-9_-]{8,}\./;
 
 function isInside(child, parent) {
   const parentPath = parent.endsWith(sep) ? parent : parent + sep;

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,108 @@
+import { createServer } from 'node:http';
+import { promises as fs } from 'node:fs';
+import { extname, join, resolve, sep } from 'node:path';
+
+const DIST_DIR = resolve(process.cwd(), 'dist');
+const PORT = Number(process.env.PORT || 3000);
+const HOST = '0.0.0.0';
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+  '.woff2': 'font/woff2',
+};
+
+function isInside(child, parent) {
+  const parentPath = parent.endsWith(sep) ? parent : parent + sep;
+  return child === parent || child.startsWith(parentPath);
+}
+
+async function readFileSafe(p) {
+  try {
+    return await fs.readFile(p);
+  } catch {
+    return null;
+  }
+}
+
+const server = createServer(async (req, res) => {
+  try {
+    const method = (req.method || 'GET').toUpperCase();
+    const urlPathRaw = decodeURIComponent((req.url || '/').split('?')[0] || '/');
+
+    if (method === 'GET' && urlPathRaw === '/health') {
+      res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end('ok');
+      return;
+    }
+
+    if (method !== 'GET' && method !== 'HEAD') {
+      res.writeHead(405, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end('Method Not Allowed');
+      return;
+    }
+
+    let urlPath = urlPathRaw;
+    if (!urlPath.startsWith('/')) urlPath = '/' + urlPath;
+
+    let filePath = resolve(DIST_DIR, '.' + urlPath);
+    // If path resolves to a directory, serve index.html within it
+    if (urlPath.endsWith('/')) {
+      filePath = resolve(filePath, 'index.html');
+    }
+
+    // Guard against path traversal
+    if (!isInside(filePath, DIST_DIR)) {
+      filePath = resolve(DIST_DIR, 'index.html');
+    }
+
+    let body = await readFileSafe(filePath);
+
+    if (!body) {
+      // SPA-like fallback
+      filePath = resolve(DIST_DIR, 'index.html');
+      body = await readFileSafe(filePath);
+    }
+
+    if (!body) {
+      res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end('Not Found');
+      return;
+    }
+
+    const ct = TYPES[extname(filePath).toLowerCase()] || 'application/octet-stream';
+    if (method === 'HEAD') {
+      res.writeHead(200, { 'content-type': ct });
+      res.end();
+    } else {
+      res.writeHead(200, { 'content-type': ct });
+      res.end(body);
+    }
+  } catch (err) {
+    try {
+      res.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end('Internal Server Error');
+    } catch {}
+  }
+});
+
+process.on('SIGTERM', () => {
+  server.close(() => process.exit(0));
+});
+process.on('SIGINT', () => {
+  server.close(() => process.exit(0));
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`[server] listening on http://${HOST}:${PORT}`);
+});

--- a/server.mjs
+++ b/server.mjs
@@ -1,16 +1,38 @@
 import { createServer } from 'node:http';
-import { promises as fs } from 'node:fs';
-import { extname, join, resolve, sep } from 'node:path';
+import { createReadStream } from 'node:fs';
+import { stat, realpath } from 'node:fs/promises';
+import { extname, resolve, normalize, sep, basename } from 'node:path';
+import { pipeline } from 'node:stream/promises';
 
-const DIST_DIR = resolve(process.cwd(), 'dist');
-const PORT = Number(process.env.PORT || 3000);
+/**
+ * Minimal, hardened static file server for production previews.
+ * - Streams files (no in-memory reads)
+ * - Canonical path validation with realpath (CodeQL-safe)
+ * - Restricts SPA fallback to HTML-eligible requests only
+ * - Correct content types, caching, Last-Modified, nosniff, Accept-Ranges: none
+ * - GET and HEAD support
+ * - Graceful shutdown with active connection tracking
+ */
+
 const HOST = '0.0.0.0';
+const PORT = Number(process.env.PORT || 3000);
+
+// Compute DIST_DIR absolute and its canonical real path once.
+const DIST_DIR = resolve(process.cwd(), 'dist');
+let DIST_REAL = DIST_DIR;
+try {
+  DIST_REAL = await realpath(DIST_DIR);
+} catch {
+  // Keep running; requests will 404 until dist exists.
+  console.warn('dist directory not found or not yet built');
+}
 
 const TYPES = {
   '.html': 'text/html; charset=utf-8',
   '.js': 'text/javascript; charset=utf-8',
   '.mjs': 'text/javascript; charset=utf-8',
   '.css': 'text/css; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
   '.json': 'application/json; charset=utf-8',
   '.svg': 'image/svg+xml',
   '.png': 'image/png',
@@ -19,89 +41,317 @@ const TYPES = {
   '.webp': 'image/webp',
   '.ico': 'image/x-icon',
   '.txt': 'text/plain; charset=utf-8',
+  '.xml': 'application/xml; charset=utf-8',
+  '.webmanifest': 'application/manifest+json; charset=utf-8',
+  '.woff': 'font/woff',
   '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.wasm': 'application/wasm',
 };
+
+const ASSET_EXTS = new Set([
+  '.js',
+  '.mjs',
+  '.css',
+  '.map',
+  '.json',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.svg',
+  '.webp',
+  '.ico',
+  '.txt',
+  '.xml',
+  '.webmanifest',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.wasm',
+]);
+
+const HASH_RE = /\.[0-9a-f]{8,}\./i;
 
 function isInside(child, parent) {
   const parentPath = parent.endsWith(sep) ? parent : parent + sep;
   return child === parent || child.startsWith(parentPath);
 }
 
-async function readFileSafe(p) {
-  try {
-    return await fs.readFile(p);
-  } catch {
-    return null;
-  }
+function getContentType(ext) {
+  return TYPES[ext] || 'application/octet-stream';
 }
 
-const server = createServer(async (req, res) => {
+function wantsHtml(acceptHeader) {
+  return typeof acceptHeader === 'string' && acceptHeader.includes('text/html');
+}
+
+function hasExtension(p) {
+  return /\.[^/]+$/.test(p);
+}
+
+async function tryServeFile(absPath, method, res) {
+  // Ensure the resolved candidate path is within the dist dir before any attempt
+  if (!isInside(absPath, DIST_DIR)) {
+    return false;
+  }
+
+  let s;
   try {
-    const method = (req.method || 'GET').toUpperCase();
-    const urlPathRaw = decodeURIComponent((req.url || '/').split('?')[0] || '/');
+    s = await stat(absPath);
+    if (!s.isFile()) return false;
+  } catch {
+    return false; // file does not exist
+  }
 
-    if (method === 'GET' && urlPathRaw === '/health') {
-      res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
-      res.end('ok');
-      return;
-    }
+  // Canonicalize and enforce that the real path is within DIST_REAL
+  let real;
+  try {
+    real = await realpath(absPath);
+  } catch {
+    return false;
+  }
+  if (!isInside(real, DIST_REAL)) {
+    // Symlink escape attempt: deny
+    return false;
+  }
 
+  const ext = extname(real).toLowerCase();
+  const ct = getContentType(ext);
+
+  const headers = {
+    'Content-Type': ct,
+    'X-Content-Type-Options': 'nosniff',
+    'Accept-Ranges': 'none',
+    'Last-Modified': s.mtime.toUTCString(),
+    'Content-Length': String(s.size),
+  };
+
+  // Cache-Control policy
+  if (ext === '.html') {
+    headers['Cache-Control'] = 'no-cache';
+  } else if (HASH_RE.test(basename(real))) {
+    headers['Cache-Control'] = 'public, max-age=31536000, immutable';
+  } else {
+    headers['Cache-Control'] = 'public, max-age=3600';
+  }
+
+  res.writeHead(200, headers);
+  if (method === 'HEAD') {
+    res.end();
+    return { bytes: 0, status: 200 };
+  }
+
+  await pipeline(createReadStream(real), res);
+  return { bytes: s.size, status: 200 };
+}
+
+function isAssetRequest(relPath) {
+  const ext = extname(relPath).toLowerCase();
+  return ext ? ASSET_EXTS.has(ext) || Object.prototype.hasOwnProperty.call(TYPES, ext) : false;
+}
+
+const sockets = new Set();
+
+const server = createServer(async (req, res) => {
+  const start = process.hrtime.bigint();
+  let status = 500;
+  let bytes;
+  let pathForLog = '-';
+  const method = (req.method || 'GET').toUpperCase();
+
+  let logged = false;
+  function logDone() {
+    if (logged) return;
+    logged = true;
+    const ms = Number(process.hrtime.bigint() - start) / 1_000_000;
+    const st = typeof res.statusCode === 'number' ? res.statusCode : status;
+    const loggedBytes =
+      typeof bytes === 'number' ? bytes : Number(res.getHeader('content-length') || 0);
+    const parts = [`method=${method}`, `path=${pathForLog}`, `status=${st}`, `ms=${ms.toFixed(1)}`];
+    if (loggedBytes > 0) parts.push(`bytes=${loggedBytes}`);
+    console.log(parts.join(' '));
+  }
+
+  res.once('finish', logDone);
+  res.once('close', logDone);
+
+  try {
     if (method !== 'GET' && method !== 'HEAD') {
-      res.writeHead(405, { 'content-type': 'text/plain; charset=utf-8' });
+      status = 405;
+      res.writeHead(405, {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'X-Content-Type-Options': 'nosniff',
+        'Accept-Ranges': 'none',
+        Allow: 'GET, HEAD',
+      });
       res.end('Method Not Allowed');
       return;
     }
 
-    let urlPath = urlPathRaw;
-    if (!urlPath.startsWith('/')) urlPath = '/' + urlPath;
-
-    let filePath = resolve(DIST_DIR, '.' + urlPath);
-    // If path resolves to a directory, serve index.html within it
-    if (urlPath.endsWith('/')) {
-      filePath = resolve(filePath, 'index.html');
-    }
-
-    // Guard against path traversal
-    if (!isInside(filePath, DIST_DIR)) {
-      filePath = resolve(DIST_DIR, 'index.html');
-    }
-
-    let body = await readFileSafe(filePath);
-
-    if (!body) {
-      // SPA-like fallback
-      filePath = resolve(DIST_DIR, 'index.html');
-      body = await readFileSafe(filePath);
-    }
-
-    if (!body) {
-      res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
-      res.end('Not Found');
+    // Decode and parse URL path
+    let urlPathRaw;
+    try {
+      const raw = (req.url || '/').split('?')[0] || '/';
+      urlPathRaw = decodeURIComponent(raw);
+    } catch (e) {
+      console.error(e?.stack || e);
+      status = 400;
+      res.writeHead(400, {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'X-Content-Type-Options': 'nosniff',
+        'Accept-Ranges': 'none',
+      });
+      res.end('Bad Request');
       return;
     }
 
-    const ct = TYPES[extname(filePath).toLowerCase()] || 'application/octet-stream';
-    if (method === 'HEAD') {
-      res.writeHead(200, { 'content-type': ct });
-      res.end();
-    } else {
-      res.writeHead(200, { 'content-type': ct });
-      res.end(body);
+    pathForLog = urlPathRaw;
+
+    // Health endpoint
+    if (urlPathRaw === '/health') {
+      status = 200;
+      const headers = {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Cache-Control': 'no-cache',
+        'X-Content-Type-Options': 'nosniff',
+        'Accept-Ranges': 'none',
+        'Content-Length': '2',
+      };
+      res.writeHead(200, headers);
+      if (method === 'HEAD') {
+        res.end();
+        bytes = 0;
+      } else {
+        res.end('ok');
+        bytes = 2;
+      }
+      return;
     }
+
+    // Normalize to a relative path (strip leading slash)
+    const stripped = urlPathRaw.startsWith('/') ? urlPathRaw.slice(1) : urlPathRaw;
+    const rel = normalize(stripped);
+    const accept = String(req.headers['accept'] || '');
+
+    // Build candidate path within dist
+    const endsWithSlash = urlPathRaw.endsWith('/');
+    const candidateRel = endsWithSlash ? normalize(rel + '/index.html') : rel;
+    const candidateAbs = resolve(DIST_DIR, candidateRel);
+
+    // Try to serve the exact file if inside dist and exists
+    let result = await tryServeFile(candidateAbs, method, res);
+    if (result) {
+      status = result.status;
+      bytes = result.bytes;
+      return;
+    }
+
+    // Not served: decide fallback vs 404
+    const reqHasExt = hasExtension(rel);
+    const reqTargetsAsset = isAssetRequest(rel);
+
+    if (reqTargetsAsset) {
+      // Static asset missing -> 404 (no SPA fallback)
+      status = 404;
+      res.writeHead(404, {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'X-Content-Type-Options': 'nosniff',
+        'Accept-Ranges': 'none',
+        'Cache-Control': 'no-cache',
+      });
+      res.end('Not Found');
+      bytes = 0;
+      return;
+    }
+
+    const htmlEligible = !reqHasExt || wantsHtml(accept);
+    if (htmlEligible) {
+      // SPA fallback to index.html
+      const indexAbs = resolve(DIST_DIR, 'index.html');
+      result = await tryServeFile(indexAbs, method, res);
+      if (result) {
+        status = result.status;
+        bytes = result.bytes;
+        return;
+      }
+      // If index missing, treat as 404
+      status = 404;
+      res.writeHead(404, {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'X-Content-Type-Options': 'nosniff',
+        'Accept-Ranges': 'none',
+        'Cache-Control': 'no-cache',
+      });
+      res.end('Not Found');
+      bytes = 0;
+      return;
+    }
+
+    // Otherwise 404
+    status = 404;
+    res.writeHead(404, {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff',
+      'Accept-Ranges': 'none',
+      'Cache-Control': 'no-cache',
+    });
+    res.end('Not Found');
+    bytes = 0;
   } catch (err) {
+    console.error(err?.stack || err);
+    status = 500;
     try {
-      res.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' });
+      res.writeHead(500, {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'X-Content-Type-Options': 'nosniff',
+        'Accept-Ranges': 'none',
+      });
       res.end('Internal Server Error');
-    } catch {}
+    } catch {
+      // ignore
+    }
   }
 });
 
-process.on('SIGTERM', () => {
-  server.close(() => process.exit(0));
+server.on('connection', (socket) => {
+  sockets.add(socket);
+  socket.on('close', () => sockets.delete(socket));
 });
-process.on('SIGINT', () => {
-  server.close(() => process.exit(0));
-});
+
+// Graceful shutdown with active connections
+let shuttingDown = false;
+function initiateShutdown() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log('shutdown=initiated');
+  server.close(() => {
+    console.log('shutdown=server-closed');
+  });
+  // Attempt graceful end of all sockets
+  sockets.forEach((s) => {
+    try {
+      s.end();
+    } catch {}
+  });
+  const t = setTimeout(() => {
+    sockets.forEach((s) => {
+      try {
+        s.destroy();
+      } catch {}
+    });
+    console.log('shutdown=forced');
+    process.exit(0);
+  }, 10_000);
+  t.unref();
+
+  server.once('close', () => {
+    console.log('shutdown=complete');
+    process.exit(0);
+  });
+}
+
+process.on('SIGTERM', initiateShutdown);
+process.on('SIGINT', initiateShutdown);
 
 server.listen(PORT, HOST, () => {
   console.log(`[server] listening on http://${HOST}:${PORT}`);


### PR DESCRIPTION
Summary\n- Add explicit production server and start command for Railway:\n  - Minimal static server with SPA fallback and health check: [server.mjs](server.mjs)\n  - Procfile to expose start: [Procfile](Procfile)\n  - Nixpacks Node 20 pin + phases (install, build, start): [nixpacks.toml](nixpacks.toml)\n  - engines and scripts.start defined: [package.json](package.json)\n- No changes to ETL scripts/utilities.\n\nLocal validation\n- Build succeeded: `npm ci && npm run build`.\n- Local production serve returned 200 for `/` and `/health` using `PORT=3000 npm run start`.\n\nResolution\nThis resolves Railway Nixpacks “No start command could be found” by providing an explicit start (`npm run start` → `node server.mjs`).

## Summary by Sourcery

Provide an explicit production server and start command for Railway by adding a static server, configuring Nixpacks for Node 20, and updating documentation for deployment.

New Features:
- Introduce minimal server (server.mjs) with SPA fallback and /health endpoint
- Add start command in package.json and Procfile for Railway production start
- Pin Node 20 and define install, build, and start phases in nixpacks.toml
- Document Railway deployment runbook and environment setup in README