### PR TITLE
Potential fix for code scanning alert no. 11: Replacement of a substring with itself

### DIFF
--- a/scripts/fetch-mitre.mjs
+++ b/scripts/fetch-mitre.mjs
@@ -132,7 +132,7 @@ function stripMarkupLocal(input) {
     .replace(/>/g, '>')
     .replace(/&/g, '&')
     .replace(/&nbsp;/g, ' ');
-  s = s.replace(/"/g, '"').replace(/'/g, "'");
+  s = s.replace(/"/g, '\\"').replace(/'/g, "\\'");
   // remove tags and collapse
   s = s
     .replace(/<[^>]+>/g, ' ')

--- a/scripts/fetch-mitre.mjs
+++ b/scripts/fetch-mitre.mjs
@@ -132,7 +132,7 @@ function stripMarkupLocal(input) {
     .replace(/>/g, '>')
     .replace(/&/g, '&')
     .replace(/&nbsp;/g, ' ');
-  s = s.replace(/"/g, '\\"').replace(/'/g, "\\'");
+  s = s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/'/g, "\\'");
   // remove tags and collapse
   s = s
     .replace(/<[^>]+>/g, ' ')


### PR DESCRIPTION
Potential fix for [https://github.com/amanthanvi/synac/security/code-scanning/11](https://github.com/amanthanvi/synac/security/code-scanning/11)

To fix this problem, we need to replace the current `.replace(/"/g, '"').replace(/'/g, "'")` calls in `stripMarkupLocal` with the actual desired transformation. If the intent was to replace `"` with `\"` and `'` with `\'`, then the replacement should be `.replace(/"/g, '\\"').replace(/'/g, "\\'")`. If the intent was instead to remove quotes from the string, the replacement should use an empty string as the replacement. Given the context—"strip markup"—it's plausible escaping was intended. The best fix is to escape quotes using backslashes (as in the CodeQL background example). These changes are to be made within the body of `stripMarkupLocal` in scripts/fetch-mitre.mjs, on line 135. No additional imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Escape double quotes to \" and single quotes to \\' instead of replacing them with themselves in stripMarkupLocal of fetch-mitre.mjs