### PR TITLE
Potential fix for code scanning alert no. 19: Replacement of a substring with itself

### DIFF
--- a/scripts/fetch-mitre.mjs
+++ b/scripts/fetch-mitre.mjs
@@ -130,7 +130,6 @@ function stripMarkupLocal(input) {
   s = s
     .replace(/</g, '<')
     .replace(/>/g, '>')
-    .replace(/&/g, '&')
     .replace(/&nbsp;/g, ' ');
   s = s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/'/g, "\\'");
   // remove tags and collapse


### PR DESCRIPTION
Potential fix for [https://github.com/amanthanvi/synac/security/code-scanning/19](https://github.com/amanthanvi/synac/security/code-scanning/19)

To fix the problem:
- Remove the redundant `.replace(/&/g, '&')` call from line 133, as it serves no functional purpose.
- Alternatively, if the goal was to HTML-escape ampersands, it should be changed to `.replace(/&/g, '&amp;')`. However, given the function is called `stripMarkupLocal` and its sequence of replacements suggests it may be trying to decode, not encode, certain entities, extra care is needed.  
- Review all the replacements for possible similar issues, such as `.replace(/</g, '<')`, `.replace(/>/g, '>')`, which are also redundant as written—either remove them or correct them to what is intended (possibly converting `<` to `&lt;` and `>` to `&gt;`).  
- Since the specific code flagged is only the `.replace(/&/g, '&')` portion, and, unless more context is given, the best minimal fix is to remove this no-op replacement, as modifying others may change functionality.

Make the change in `scripts/fetch-mitre.mjs`, specifically editing the function `stripMarkupLocal`, line 133, to remove the redundant replacement.

No new imports or methods are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Remove the no-op .replace(/&/g, '&') call from stripMarkupLocal in fetch-mitre.mjs