### PR TITLE
feat(search): synonym/alias graph + filters + tests

### DIFF
--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -24,6 +24,7 @@ const title = 'Quick search';
     <span id="count" role="status" aria-live="polite" aria-atomic="true" class="muted fs-90"></span>
   </div>
 
+  <!-- Sources facet -->
   <div id="filters" class="chips" aria-label="Filter by source kind">
     <button type="button" class="btn-chip" data-kind="NIST" aria-pressed="false">NIST</button>
     <button type="button" class="btn-chip" data-kind="RFC" aria-pressed="false">RFC</button>
@@ -32,6 +33,27 @@ const title = 'Quick search';
     <button type="button" class="btn-chip" data-kind="CAPEC" aria-pressed="false">CAPEC</button>
     <button type="button" class="btn-chip" data-kind="OTHER" aria-pressed="false">Other</button>
   </div>
+
+  <!-- Types facet -->
+  <div id="type-filters" class="chips mt-2" aria-label="Filter by type or category">
+    <button type="button" class="btn-chip" data-type="protocol" aria-pressed="false"
+      >Protocol</button
+    >
+    <button type="button" class="btn-chip" data-type="vulnerability" aria-pressed="false"
+      >Vulnerability</button
+    >
+    <button type="button" class="btn-chip" data-type="attack-pattern" aria-pressed="false"
+      >Attack pattern</button
+    >
+    <button type="button" class="btn-chip" data-type="crypto" aria-pressed="false">Crypto</button>
+    <button type="button" class="btn-chip" data-type="identity" aria-pressed="false"
+      >Identity</button
+    >
+    <button type="button" class="btn-chip" data-type="concept" aria-pressed="false">Concept</button>
+  </div>
+
+  <!-- Tags facet (chips are injected by client) -->
+  <div id="tag-filters" class="chips mt-2" aria-label="Filter by tags"></div>
 
   <ul id="results" role="list" class="list-unstyled grid gap-2 mt-4"></ul>
 </section>

--- a/src/lib/facets.ts
+++ b/src/lib/facets.ts
@@ -1,0 +1,78 @@
+/**
+ * Facet derivation helpers shared at build time.
+ * Keep heuristics minimal and deterministic.
+ */
+
+export type SourceKind = 'NIST' | 'ATTACK' | 'CWE' | 'CAPEC' | 'RFC' | 'OTHER';
+
+export function deriveSourceKinds(data: any): SourceKind[] {
+  const kinds = new Set<SourceKind>();
+
+  // From explicit sources.kind
+  const sources: Array<any> = Array.isArray(data?.sources) ? data.sources : [];
+  for (const s of sources) {
+    const k = String(s?.kind || '').toUpperCase();
+    if (k === 'NIST' || k === 'ATTACK' || k === 'CWE' || k === 'CAPEC' || k === 'RFC') {
+      kinds.add(k as SourceKind);
+    }
+    const url = String(s?.url || '');
+    const citation = String(s?.citation || '');
+    if (url.includes('nist.gov') || citation.toUpperCase().includes('NIST')) kinds.add('NIST');
+  }
+
+  // From mappings presence
+  const mappings = data?.mappings || {};
+  if (Array.isArray(mappings?.cweIds) && mappings.cweIds.length) kinds.add('CWE');
+  if (Array.isArray(mappings?.capecIds) && mappings.capecIds.length) kinds.add('CAPEC');
+  if (
+    (mappings?.attack && (mappings.attack.tactic || (mappings.attack.techniqueIds || []).length)) ||
+    // Some content may have legacy 'attack' array
+    (Array.isArray(mappings?.attack) && mappings.attack.length)
+  ) {
+    kinds.add('ATTACK');
+  }
+
+  if (kinds.size === 0) kinds.add('OTHER');
+  return Array.from(kinds);
+}
+
+function isLikelyProtocol(term: string, tags: string[]): boolean {
+  if (tags.includes('protocol')) return true;
+  const t = term.toLowerCase();
+  // Heuristic keywords that strongly indicate a protocol or wire format
+  const hints = [
+    'http',
+    'tls',
+    'ssl',
+    'udp',
+    'tcp',
+    'dns',
+    'dnssec',
+    'quic',
+    'ocsp',
+    'hsts',
+    'http/2',
+    'http2',
+    'http3',
+  ];
+  return hints.some((h) => t.includes(h));
+}
+
+export type TypeCategory =
+  | 'protocol'
+  | 'vulnerability'
+  | 'attack-pattern'
+  | 'crypto'
+  | 'identity'
+  | 'concept';
+
+export function deriveTypeCategory(term: string, tagsInput: any, mappings: any): TypeCategory {
+  const tags: string[] = Array.isArray(tagsInput) ? tagsInput.map((t) => String(t)) : [];
+
+  if (Array.isArray(mappings?.cweIds) && mappings.cweIds.length) return 'vulnerability';
+  if (Array.isArray(mappings?.capecIds) && mappings.capecIds.length) return 'attack-pattern';
+  if (isLikelyProtocol(term, tags)) return 'protocol';
+  if (tags.includes('crypto')) return 'crypto';
+  if (tags.includes('auth') || tags.includes('identity')) return 'identity';
+  return 'concept';
+}

--- a/src/lib/searchBuild.ts
+++ b/src/lib/searchBuild.ts
@@ -1,4 +1,9 @@
 import MiniSearch from 'minisearch';
+import { searchOptions } from './searchOptions';
+import { normalizePhrases, normalizeTokens } from './tokenize';
+// JSON import is build-time only; not shipped to client
+// @ts-ignore - resolveJsonModule is provided by Astro's tsconfig
+import SYNONYMS from '../search/synonyms.json';
 
 export type SearchDoc = {
   id: string;
@@ -8,26 +13,53 @@ export type SearchDoc = {
   text: string;
   tags: string[];
   sourceKinds: string[];
+  // Derived fields (not necessarily stored in payload)
+  typeCategory?: string;
+  aliasTokens?: string[];
+  slugTokens?: string[];
+  titleTokens?: string[];
 };
 
-export const searchOptions = {
-  idField: 'id',
-  fields: ['term', 'acronym', 'aliases', 'text', 'tags', 'sourceKinds'],
-  storeFields: ['id', 'term', 'acronym', 'aliases', 'tags', 'sourceKinds'],
-  searchOptions: {
-    prefix: true,
-    fuzzy: 0.2,
-    boost: { term: 2, acronym: 2, aliases: 1.5 },
-  },
-} as const;
+type SynonymEntry = {
+  aliases?: string[];
+  sources?: Array<{ label: string; id: string; type?: string }>;
+};
+type SynonymMap = Record<string, SynonymEntry | undefined>;
+
+/**
+ * Augment a document with normalized token fields and canonical aliasTokens.
+ * - Highest boost: slugTokens (id) and titleTokens (term)
+ * - Medium: aliasTokens (from synonyms.json and frontmatter aliases)
+ * - Lower: text/tags/sourceKinds (handled by searchOptions boosts)
+ */
+function enrichDoc(doc: SearchDoc, synonyms: SynonymMap): SearchDoc {
+  const slugTokens = normalizeTokens(doc.id);
+  const titleTokens = normalizeTokens(doc.term);
+
+  // Start with any frontmatter-provided aliases, then add canonical synonyms keyed by slug
+  const aliasPhrases = Array.isArray(doc.aliases) ? doc.aliases : [];
+  const canonical = synonyms[doc.id]?.aliases || [];
+  const aliasTokens = Array.from(
+    new Set<string>([...normalizePhrases(aliasPhrases), ...normalizePhrases(canonical)]),
+  );
+
+  return {
+    ...doc,
+    slugTokens,
+    titleTokens,
+    aliasTokens,
+  };
+}
 
 /**
  * Build a MiniSearch index payload given normalized docs.
- * Returns the options and a serialized index JSON that can be revived on the client via MiniSearch.loadJSON.
+ * Returns options and a serialized index JSON that can be revived client-side via MiniSearch.loadJSON.
+ * Important: we do not create extra documents; we only expand the token vocabulary for existing docs.
  */
 export function buildIndexPayload(docs: SearchDoc[]) {
+  const expanded = docs.map((d) => enrichDoc(d, SYNONYMS as SynonymMap));
   const mini = new MiniSearch(searchOptions as any);
-  mini.addAll(docs);
+  mini.addAll(expanded as any);
   return {
     options: searchOptions,
     index: JSON.stringify(mini.toJSON()),

--- a/src/lib/searchOptions.ts
+++ b/src/lib/searchOptions.ts
@@ -1,0 +1,32 @@
+import type {} from 'minisearch';
+
+/**
+ * Shared MiniSearch options used on both server (index build) and client (query).
+ * This module contains NO server-only imports to keep client bundle lean.
+ */
+export const searchOptions = {
+  idField: 'id',
+  // Fields participating in search scoring
+  fields: [
+    'slugTokens', // highest boost: exact id/slug tokens
+    'titleTokens', // high boost: title tokens
+    'acronym', // high-ish boost: acronym
+    'aliasTokens', // medium: canonical alias tokens
+    'text', // lower: summary/body excerpt
+    'tags', // lower: tags
+  ],
+  // Fields returned on each hit (keep minimal to control payload size)
+  storeFields: ['id', 'term', 'acronym', 'tags', 'sourceKinds', 'typeCategory', 'aliasTokens'],
+  searchOptions: {
+    prefix: true,
+    fuzzy: 0.2,
+    boost: {
+      slugTokens: 3.0,
+      titleTokens: 2.5,
+      acronym: 2.2,
+      aliasTokens: 1.8,
+      text: 1.0,
+      tags: 1.0,
+    },
+  },
+} as const;

--- a/src/lib/tokenize.ts
+++ b/src/lib/tokenize.ts
@@ -1,0 +1,98 @@
+/**
+ * Normalization and tokenization helpers shared by server (build) and client (query).
+ * - Lowercase
+ * - Fold punctuation
+ * - Expand "/" and "-" variants into additional tokens
+ * - Provide special-case expansions for common security terms
+ *
+ * NOTE: This file is safe for client usage (no server-only imports).
+ */
+
+function stripDiacritics(s: string): string {
+  // NFKD normalize then drop combining marks
+  return s.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
+}
+
+function basicClean(s: string): string {
+  return (
+    stripDiacritics(s)
+      .toLowerCase()
+      // unify unicode dashes to "-"
+      .replace(/[\u2012-\u2015\u2212]/g, '-')
+      // remove most punctuation to spaces (keep "/" and "-" for later handling)
+      .replace(/[!"#$%&'()*+,.:;<=>?@[\\\]^_`{|}~]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}
+
+/**
+ * Expand tokens for separators "/" and "-" into:
+ * - split parts (e.g., "http/2" -> "http","2")
+ * - joined composite (e.g., "http/2" -> "http2", "ssl-tls" -> "ssltls")
+ */
+function expandSepVariants(tok: string): string[] {
+  const out = new Set<string>();
+  if (!tok) return [];
+  out.add(tok);
+
+  if (tok.includes('/')) {
+    const parts = tok.split('/').filter(Boolean);
+    for (const p of parts) out.add(p);
+    out.add(tok.replace(/\//g, ''));
+  }
+  if (tok.includes('-')) {
+    const parts = tok.split('-').filter(Boolean);
+    for (const p of parts) out.add(p);
+    out.add(tok.replace(/-/g, ''));
+  }
+
+  // Special-case expansions
+  const hyphensToSpace = tok.replace(/-/g, ' ');
+  if (hyphensToSpace === 'denial of service') {
+    out.add('dos');
+  }
+  if (tok === 'http/2' || hyphensToSpace === 'http 2' || tok === 'http2') {
+    out.add('http2');
+  }
+
+  return Array.from(out);
+}
+
+/**
+ * Normalize an input string into a set of tokens with separator variants.
+ */
+export function normalizeTokens(input: string): string[] {
+  const cleaned = basicClean(input);
+  if (!cleaned) return [];
+  const raw = cleaned
+    // keep "/" and "-" for variant expansion, but split on spaces
+    .split(/\s+/)
+    .filter(Boolean);
+  const out = new Set<string>();
+  for (const tok of raw) {
+    for (const v of expandSepVariants(tok)) {
+      if (v.length >= 1) out.add(v);
+    }
+  }
+  return Array.from(out);
+}
+
+/**
+ * Normalize a list of phrases into a unique token set.
+ */
+export function normalizePhrases(phrases: Array<string | undefined | null>): string[] {
+  const out = new Set<string>();
+  for (const p of phrases) {
+    if (!p) continue;
+    for (const t of normalizeTokens(String(p))) out.add(t);
+  }
+  return Array.from(out);
+}
+
+/**
+ * Convenience for query normalization.
+ */
+export function normalizeQuery(q: string): string[] {
+  return normalizeTokens(q);
+}

--- a/src/pages/search.json.ts
+++ b/src/pages/search.json.ts
@@ -1,7 +1,22 @@
 import { getCollection } from 'astro:content';
 import { buildIndexPayload } from '../lib/searchBuild';
+import { deriveSourceKinds, deriveTypeCategory } from '../lib/facets';
 declare const __BUILD_TIME__: string | number;
 
+/**
+ * /search.json payload
+ * Shape:
+ * {
+ *   v: buildTimestamp,
+ *   options: MiniSearch options (including boosts),
+ *   index: stringified MiniSearch JSON (revivable with MiniSearch.loadJSON)
+ * }
+ * Stored fields per document (kept minimal):
+ *   id, term, acronym, tags, sourceKinds, typeCategory, aliasTokens, slugTokens, titleTokens
+ * Notes:
+ * - Synonym expansion occurs at build time (server); no client import of synonyms.json.
+ * - Avoid embedding heavy source objects to keep payload lean.
+ */
 export const prerender = true;
 
 type Doc = {
@@ -12,6 +27,7 @@ type Doc = {
   text: string;
   tags: string[];
   sourceKinds: string[];
+  typeCategory: string;
 };
 
 function unique<T>(arr: T[]): T[] {
@@ -31,9 +47,9 @@ export async function GET() {
 
   const docs: Doc[] = entries.map((e) => {
     const data = e.data as any;
-    const sourceKinds = unique<string>(
-      (data.sources || []).map((s: any) => String(s.kind || 'OTHER')),
-    );
+    const tags: string[] = Array.isArray(data.tags) ? data.tags.map((t: any) => String(t)) : [];
+    const sourceKinds = deriveSourceKinds(data);
+    const typeCategory = deriveTypeCategory(String(data.term || ''), tags, data.mappings || {});
     return {
       id: e.slug,
       term: data.term,
@@ -41,18 +57,27 @@ export async function GET() {
       aliases: data.aliases,
       text: [
         data.summary,
-        ...(data.sources || []).map((s: any) => `${s.citation || ''} ${s.excerpt || ''}`),
+        ...(Array.isArray(data.sources) ? data.sources : []).map(
+          (s: any) => `${s.citation || ''} ${s.excerpt || ''}`,
+        ),
       ]
         .filter(Boolean)
         .join(' '),
-      tags: data.tags || [],
-      sourceKinds,
+      tags,
+      sourceKinds: unique(sourceKinds),
+      typeCategory,
     };
   });
 
+  // Build MiniSearch index with enriched token fields and alias expansion
   const payload = buildIndexPayload(docs as any);
 
-  return new Response(JSON.stringify({ v: __BUILD_TIME__, ...payload }), {
+  // Minimal meta for client UI (tags multi-select). Kept small to preserve budgets.
+  const tagsMeta = Array.from(
+    new Set(docs.flatMap((d) => (Array.isArray(d.tags) ? d.tags : []))),
+  ).sort();
+
+  return new Response(JSON.stringify({ v: __BUILD_TIME__, tags: tagsMeta, ...payload }), {
     headers: { 'content-type': 'application/json; charset=utf-8' },
   });
 }

--- a/src/scripts/searchClient.ts
+++ b/src/scripts/searchClient.ts
@@ -1,6 +1,7 @@
 import MiniSearch from 'minisearch';
-import { searchOptions } from '../lib/searchBuild';
+import { searchOptions } from '../lib/searchOptions';
 import { ENABLE_TELEMETRY } from '../lib/constants';
+import { normalizeQuery, normalizeTokens } from '../lib/tokenize';
 declare const __BUILD_TIME__: string | number;
 
 // Globals for test coordination
@@ -14,10 +15,29 @@ declare global {
   const input = document.getElementById('q') as HTMLInputElement | null;
   const list = document.getElementById('results') as HTMLUListElement | null;
   const count = document.getElementById('count') as HTMLElement | null;
-  const filters = document.getElementById('filters') as HTMLDivElement | null;
-  const activeKinds = new Set<string>();
+
+  // Facet containers
+  const sourceFilters = document.getElementById('filters') as HTMLDivElement | null; // Sources
+  const typeFilters = document.getElementById('type-filters') as HTMLDivElement | null; // Types
+  const tagFilters = document.getElementById('tag-filters') as HTMLDivElement | null; // Tags (chips, dynamic)
 
   if (!input || !list || !count) return;
+
+  // Supported facet values (stable)
+  const SUPPORTED_SOURCES = new Set(['NIST', 'ATTACK', 'CWE', 'CAPEC', 'RFC']);
+  const SUPPORTED_TYPES = new Set([
+    'protocol',
+    'vulnerability',
+    'attack-pattern',
+    'crypto',
+    'identity',
+    'concept',
+  ]);
+
+  // Current selections
+  let selectedSources = new Set<string>();
+  let selectedTypes = new Set<string>();
+  let selectedTags = new Set<string>();
 
   // Keyboard shortcuts: "/" to focus search, "Escape" to clear/blur
   window.addEventListener('keydown', (e) => {
@@ -27,7 +47,6 @@ declare global {
     const isContentEditable = !!(active && (active as HTMLElement).isContentEditable);
     const isReadOnly = !!(active && 'readOnly' in (active as any) && (active as any).readOnly);
     const isDisabled = !!(active && 'disabled' in (active as any) && (active as any).disabled);
-    // Only treat as editing if it's a form element AND not readOnly/disabled, or if it's contentEditable
     const isEditing = (isFormEl && !isReadOnly && !isDisabled) || isContentEditable;
 
     if (e.key === '/' && !isEditing) {
@@ -35,6 +54,7 @@ declare global {
       input.focus();
     } else if (e.key === 'Escape' && document.activeElement === input) {
       input.value = '';
+      updateUrlFromState();
       render([]);
       input.blur();
     }
@@ -43,6 +63,7 @@ declare global {
   let mini: MiniSearch | null = null;
   // Will be replaced by payload.options.searchOptions if present
   let currentSearchOptions: any = searchOptions.searchOptions;
+  let availableTags: string[] = [];
 
   function escapeHtml(s: string) {
     return String(s)
@@ -80,20 +101,37 @@ declare global {
       const li = document.createElement('li');
       li.className = 'result-item';
       li.setAttribute('role', 'listitem');
+
       const a = document.createElement('a');
       a.href = `/terms/${it.id}`;
       a.className = 'result-link';
+
       const title = document.createElement('div');
       title.className = 'result-title';
+
       const strong = document.createElement('strong');
       strong.innerHTML = highlight(String(it.term || ''), tokens);
       title.appendChild(strong);
+
+      // Alias badge (non-intrusive)
+      if (it.matchedViaAlias) {
+        const ab = document.createElement('span');
+        ab.className = 'badge';
+        ab.textContent = 'Alias match';
+        const sr = document.createElement('span');
+        sr.className = 'sr-only';
+        sr.textContent = ' (matched via alias)';
+        ab.appendChild(sr);
+        title.appendChild(ab);
+      }
+
       if (Array.isArray(it.acronym) && it.acronym.length) {
         const badge = document.createElement('span');
         badge.className = 'badge';
         badge.textContent = it.acronym.join(', ');
         title.appendChild(badge);
       }
+
       if (Array.isArray(it.sourceKinds) && it.sourceKinds.length) {
         for (const k of it.sourceKinds) {
           const kind = document.createElement('span');
@@ -102,10 +140,13 @@ declare global {
           title.appendChild(kind);
         }
       }
+
       const meta = document.createElement('div');
       meta.className = 'result-meta';
-      if (Array.isArray(it.tags) && it.tags.length)
+      if (Array.isArray(it.tags) && it.tags.length) {
         meta.textContent = it.tags.map((t: string) => `#${t}`).join(' ');
+      }
+
       a.appendChild(title);
       a.appendChild(meta);
       li.appendChild(a);
@@ -137,6 +178,101 @@ declare global {
     } catch {}
     return m;
   };
+
+  function parseUrlState() {
+    const usp = new URLSearchParams(location.search);
+    const q = usp.get('q') || '';
+    const splitCsv = (v: string | null) =>
+      (v ? v.split(',') : []).map((s) => s.trim()).filter(Boolean);
+    const sources = splitCsv(usp.get('sources'))
+      .map((s) => s.toUpperCase())
+      .filter((s) => SUPPORTED_SOURCES.has(s));
+    const types = splitCsv(usp.get('types')).filter((t) => SUPPORTED_TYPES.has(t));
+    const tags = splitCsv(usp.get('tags'));
+    return { q, sources, types, tags };
+  }
+
+  function updateUrlFromState(push = false) {
+    const usp = new URLSearchParams(location.search);
+    // Preserve unknown params by deleting only known keys
+    for (const k of ['q', 'sources', 'types', 'tags']) usp.delete(k);
+
+    const q = input!.value.trim();
+    if (q) usp.set('q', q);
+    if (selectedSources.size) usp.set('sources', Array.from(selectedSources).join(','));
+    if (selectedTypes.size) usp.set('types', Array.from(selectedTypes).join(','));
+    if (selectedTags.size) usp.set('tags', Array.from(selectedTags).join(','));
+
+    const newUrl = `${location.pathname}?${usp.toString()}${location.hash || ''}`;
+    if (push) {
+      history.pushState(null, '', newUrl);
+    } else {
+      history.replaceState(null, '', newUrl);
+    }
+  }
+
+  function syncUiFromState() {
+    const st = parseUrlState();
+    input!.value = st.q;
+    selectedSources = new Set(st.sources);
+    selectedTypes = new Set(st.types);
+    selectedTags = new Set(st.tags);
+
+    // sync source chips aria-pressed
+    if (sourceFilters) {
+      const buttons = Array.from(
+        sourceFilters.querySelectorAll('button[data-kind]'),
+      ) as HTMLButtonElement[];
+      for (const btn of buttons) {
+        const kind = btn.getAttribute('data-kind') || '';
+        const on = selectedSources.has(kind);
+        btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+        btn.classList.toggle('btn-chip--active', on);
+      }
+    }
+    // sync type chips
+    if (typeFilters) {
+      const buttons = Array.from(
+        typeFilters.querySelectorAll('button[data-type]'),
+      ) as HTMLButtonElement[];
+      for (const btn of buttons) {
+        const t = btn.getAttribute('data-type') || '';
+        const on = selectedTypes.has(t);
+        btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+        btn.classList.toggle('btn-chip--active', on);
+      }
+    }
+    // sync tags (if rendered already)
+    if (tagFilters) {
+      const buttons = Array.from(
+        tagFilters.querySelectorAll('button[data-tag]'),
+      ) as HTMLButtonElement[];
+      for (const btn of buttons) {
+        const t = btn.getAttribute('data-tag') || '';
+        const on = selectedTags.has(t);
+        btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+        btn.classList.toggle('btn-chip--active', on);
+      }
+    }
+  }
+
+  function renderTagChips() {
+    if (!tagFilters) return;
+    tagFilters.innerHTML = '';
+    if (!availableTags || !availableTags.length) return;
+    const frag = document.createDocumentFragment();
+    for (const tag of availableTags) {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'btn-chip';
+      b.setAttribute('data-tag', tag);
+      b.setAttribute('aria-pressed', selectedTags.has(tag) ? 'true' : 'false');
+      b.textContent = `#${tag}`;
+      if (selectedTags.has(tag)) b.classList.add('btn-chip--active');
+      frag.appendChild(b);
+    }
+    tagFilters.appendChild(frag);
+  }
 
   const ensureIndex = async (): Promise<MiniSearch | null> => {
     if (mini) return mini;
@@ -178,6 +314,13 @@ declare global {
       }
       currentSearchOptions =
         (payload.options && payload.options.searchOptions) || currentSearchOptions;
+
+      // tags meta for rendering tag chips
+      if (Array.isArray(payload.tags)) {
+        availableTags = payload.tags.slice(0, 300); // keep UI manageable
+        renderTagChips();
+      }
+
       try {
         window.__synacIndexReady = true;
       } catch {}
@@ -196,11 +339,57 @@ declare global {
     }
   };
 
+  function applyFacetFilters(results: any[], qTokens: string[]): any[] {
+    const srcSel = Array.from(selectedSources);
+    const typeSel = Array.from(selectedTypes);
+    const tagSel = Array.from(selectedTags);
+
+    // Decorate results with matchedViaAlias and apply deterministic tie-break
+    const decorated = results.map((r: any) => {
+      const aliasTokens: string[] = Array.isArray(r.aliasTokens) ? r.aliasTokens : [];
+      const aliasHit = aliasTokens.length ? aliasTokens.some((t) => qTokens.includes(t)) : false;
+      const idHit = normalizeTokens(String(r.id || '')).some((t) => qTokens.includes(t));
+      const titleHit = normalizeTokens(String(r.term || '')).some((t) => qTokens.includes(t));
+      const matchedViaAlias = !!(aliasHit && !(idHit || titleHit));
+      return { ...r, matchedViaAlias };
+    });
+
+    const filtered = decorated.filter((r: any) => {
+      // sources: AND within group (doc must include all selected source kinds)
+      if (srcSel.length) {
+        const kinds: string[] = Array.isArray(r.sourceKinds) ? r.sourceKinds : [];
+        for (const s of srcSel) if (!kinds.includes(s)) return false;
+      }
+      // types: membership (OR within group)
+      if (typeSel.length) {
+        const t = String(r.typeCategory || '');
+        if (!typeSel.includes(t)) return false;
+      }
+      // tags: AND within group (doc must include all selected tags)
+      if (tagSel.length) {
+        const tags: string[] = Array.isArray(r.tags) ? r.tags : [];
+        for (const t of tagSel) if (!tags.includes(t)) return false;
+      }
+      return true;
+    });
+
+    // Deterministic sort: score desc, then id asc
+    filtered.sort((a: any, b: any) => {
+      const sa = typeof a.score === 'number' ? a.score : 0;
+      const sb = typeof b.score === 'number' ? b.score : 0;
+      if (sb !== sa) return sb - sa;
+      return String(a.id || '').localeCompare(String(b.id || ''));
+    });
+
+    return filtered;
+  }
+
   const onInput = async () => {
     const q = input!.value.trim();
     const m = await ensureIndex();
     if (!m) return;
     if (!q) {
+      updateUrlFromState();
       render([], []);
       return;
     }
@@ -222,50 +411,96 @@ declare global {
         }
       } catch {}
     }
-    const tokens = q.toLowerCase().split(/\s+/).filter(Boolean);
-    // In DOM fallback mode, docs do not contain sourceKinds; bypass kind filtering
+    const qTokens = normalizeQuery(q);
+    // In DOM fallback mode, docs do not contain facets; bypass filtering
     const isFallback = !!(
       count &&
       (count as HTMLElement).dataset &&
       (count as HTMLElement).dataset.mode === 'fallback'
     );
-    const filtered =
-      activeKinds.size && !isFallback
-        ? results.filter(
-            (r: any) =>
-              Array.isArray(r.sourceKinds) &&
-              r.sourceKinds.some((k: string) => activeKinds.has(String(k))),
-          )
-        : results;
-    render(filtered, tokens);
+    const filtered = isFallback ? results : applyFacetFilters(results, qTokens);
+    render(filtered, qTokens);
   };
 
+  // Input change -> update URL and search
   input.addEventListener('input', () => {
+    updateUrlFromState();
     void onInput();
   });
 
-  if (filters) {
-    filters.addEventListener('click', (e) => {
+  // Source facet toggles
+  if (sourceFilters) {
+    sourceFilters.addEventListener('click', (e) => {
       const target = (e.target as HTMLElement).closest(
         'button[data-kind]',
       ) as HTMLButtonElement | null;
       if (!target) return;
       const kind = target.getAttribute('data-kind');
       if (!kind) return;
-      if (activeKinds.has(kind)) {
-        activeKinds.delete(kind);
-        target.setAttribute('aria-pressed', 'false');
-        target.classList.remove('btn-chip--active');
-      } else {
-        activeKinds.add(kind);
-        target.setAttribute('aria-pressed', 'true');
-        target.classList.add('btn-chip--active');
-      }
-      // Re-run search with current query (may be empty)
+      const next = target.getAttribute('aria-pressed') !== 'true';
+      target.setAttribute('aria-pressed', next ? 'true' : 'false');
+      target.classList.toggle('btn-chip--active', next);
+      if (next) selectedSources.add(kind);
+      else selectedSources.delete(kind);
+      updateUrlFromState();
       queueMicrotask(onInput);
     });
   }
 
-  // Warm index in background
-  ensureIndex().catch(() => {});
+  // Type facet toggles
+  if (typeFilters) {
+    typeFilters.addEventListener('click', (e) => {
+      const target = (e.target as HTMLElement).closest(
+        'button[data-type]',
+      ) as HTMLButtonElement | null;
+      if (!target) return;
+      const t = target.getAttribute('data-type');
+      if (!t) return;
+      const next = target.getAttribute('aria-pressed') !== 'true';
+      target.setAttribute('aria-pressed', next ? 'true' : 'false');
+      target.classList.toggle('btn-chip--active', next);
+      if (next) selectedTypes.add(t);
+      else selectedTypes.delete(t);
+      updateUrlFromState();
+      queueMicrotask(onInput);
+    });
+  }
+
+  // Tag facet toggles
+  if (tagFilters) {
+    tagFilters.addEventListener('click', (e) => {
+      const target = (e.target as HTMLElement).closest(
+        'button[data-tag]',
+      ) as HTMLButtonElement | null;
+      if (!target) return;
+      const t = target.getAttribute('data-tag');
+      if (!t) return;
+      const next = target.getAttribute('aria-pressed') !== 'true';
+      target.setAttribute('aria-pressed', next ? 'true' : 'false');
+      target.classList.toggle('btn-chip--active', next);
+      if (next) selectedTags.add(t);
+      else selectedTags.delete(t);
+      updateUrlFromState();
+      queueMicrotask(onInput);
+    });
+  }
+
+  // Support back/forward navigation to update UI and rerun queries
+  window.addEventListener('popstate', () => {
+    syncUiFromState();
+    void onInput();
+  });
+
+  // Initialize from URL, warm index and render tags (if available in payload)
+  syncUiFromState();
+  ensureIndex()
+    .then(() => {
+      renderTagChips();
+      syncUiFromState();
+      if (input!.value.trim()) void onInput();
+      try {
+        window.__synacIndexReady = true;
+      } catch {}
+    })
+    .catch(() => {});
 })();

--- a/src/search/synonyms.json
+++ b/src/search/synonyms.json
@@ -1,0 +1,26 @@
+{
+  "jwt": {
+    "aliases": ["json web token", "jot", "jwt token"],
+    "sources": [{ "label": "rfc", "id": "7519", "type": "normative" }]
+  },
+  "tls": {
+    "aliases": ["ssl", "secure sockets layer", "ssl/tls"],
+    "sources": [{ "label": "rfc", "id": "8446", "type": "normative" }]
+  },
+  "aitm": {
+    "aliases": ["mitm", "man-in-the-middle", "man in the middle"],
+    "sources": [{ "label": "capec", "id": "94", "type": "normative" }]
+  },
+  "csrf": {
+    "aliases": ["cross site request forgery", "cross-site request forgery"]
+  },
+  "xss": {
+    "aliases": ["cross site scripting", "cross-site scripting"]
+  },
+  "dos": {
+    "aliases": ["denial-of-service", "denial of service", "dos attack"]
+  },
+  "http2": {
+    "aliases": ["http/2", "http 2"]
+  }
+}

--- a/tests/unit/search-combinedFilters.test.ts
+++ b/tests/unit/search-combinedFilters.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import MiniSearch from 'minisearch';
+import { buildIndexPayload, type SearchDoc } from '../../src/lib/searchBuild';
+import { searchOptions } from '../../src/lib/searchOptions';
+
+function applyFacetFilters(
+  results: any[],
+  opts: { sources?: string[]; types?: string[]; tags?: string[] },
+) {
+  const srcSel = opts.sources || [];
+  const typeSel = opts.types || [];
+  const tagSel = opts.tags || [];
+
+  const filtered = results.filter((r: any) => {
+    if (srcSel.length) {
+      const kinds: string[] = Array.isArray(r.sourceKinds) ? r.sourceKinds : [];
+      for (const s of srcSel) if (!kinds.includes(s)) return false;
+    }
+    if (typeSel.length) {
+      const t = String(r.typeCategory || '');
+      if (!typeSel.includes(t)) return false;
+    }
+    if (tagSel.length) {
+      const tags: string[] = Array.isArray(r.tags) ? r.tags : [];
+      for (const t of tagSel) if (!tags.includes(t)) return false;
+    }
+    return true;
+  });
+
+  filtered.sort((a: any, b: any) => {
+    const sa = typeof a.score === 'number' ? a.score : 0;
+    const sb = typeof b.score === 'number' ? b.score : 0;
+    if (sb !== sa) return sb - sa;
+    return String(a.id || '').localeCompare(String(b.id || ''));
+  });
+
+  return filtered;
+}
+
+describe('search: combined facet filters', () => {
+  it('query "token" + source=RFC + type ∈ {concept,identity} yields JWT/JWS/JWE subset', () => {
+    const docs: SearchDoc[] = [
+      // JOSE family (RFC + token-related)
+      {
+        id: 'jwt',
+        term: 'JSON Web Token',
+        acronym: ['JWT'],
+        aliases: ['jwt token'],
+        text: 'token rfc claims',
+        tags: ['auth', 'tokens', 'rfc'],
+        sourceKinds: ['RFC'],
+        // keep consistent with our heuristic (identity)
+        // @ts-ignore stored by MiniSearch via storeFields
+        typeCategory: 'identity',
+      },
+      {
+        id: 'jws',
+        term: 'JSON Web Signature',
+        acronym: ['JWS'],
+        aliases: [],
+        text: 'token signature rfc',
+        tags: ['tokens', 'rfc'],
+        sourceKinds: ['RFC'],
+        // @ts-ignore
+        typeCategory: 'concept',
+      },
+      {
+        id: 'jwe',
+        term: 'JSON Web Encryption',
+        acronym: ['JWE'],
+        aliases: [],
+        text: 'token encryption rfc',
+        tags: ['tokens', 'rfc'],
+        sourceKinds: ['RFC'],
+        // @ts-ignore
+        typeCategory: 'concept',
+      },
+      // A protocol but not a token; used to validate narrowing
+      {
+        id: 'tls',
+        term: 'Transport Layer Security',
+        acronym: ['TLS'],
+        aliases: ['ssl/tls'],
+        text: 'protocol cryptography',
+        tags: ['crypto', 'rfc'],
+        sourceKinds: ['RFC'],
+        // @ts-ignore
+        typeCategory: 'protocol',
+      },
+      // A vulnerability (non-RFC)
+      {
+        id: 'xss',
+        term: 'Cross-Site Scripting',
+        acronym: ['XSS'],
+        aliases: ['cross site scripting'],
+        text: 'web vulnerability cwe capec',
+        tags: ['web', 'cwe', 'capec'],
+        sourceKinds: ['CWE', 'CAPEC'],
+        // @ts-ignore
+        typeCategory: 'vulnerability',
+      },
+    ];
+
+    const payload = buildIndexPayload(docs);
+    const mini = MiniSearch.loadJSON(payload.index as string, payload.options as any);
+
+    const raw = mini.search('token', searchOptions.searchOptions);
+    const filtered = applyFacetFilters(raw as any, {
+      sources: ['RFC'],
+      types: ['concept', 'identity'],
+    });
+    const ids = filtered.map((r: any) => r.id);
+
+    // Expect only JWT/JWS/JWE in deterministic order by score then id
+    expect(ids).toEqual(expect.arrayContaining(['jwt', 'jws', 'jwe']));
+    expect(ids).not.toContain('tls');
+    expect(ids).not.toContain('xss');
+
+    // Removing source=RFC broadens set deterministically to include TLS
+    const broader = applyFacetFilters(raw as any, { types: ['concept', 'identity'] });
+    const broaderIds = broader.map((r: any) => r.id);
+    expect(broaderIds).toEqual(expect.arrayContaining(['tls', 'jwt', 'jws', 'jwe']));
+  });
+});

--- a/tests/unit/search-facets.test.ts
+++ b/tests/unit/search-facets.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { deriveSourceKinds, deriveTypeCategory } from '../../src/lib/facets';
+
+describe('search: facet derivation', () => {
+  it('JWT (RFC) → sourceKinds includes RFC; typeCategory identity (heuristic)', () => {
+    const jwt = {
+      term: 'JSON Web Token (JWT)',
+      tags: ['auth', 'tokens', 'rfc'],
+      sources: [
+        {
+          kind: 'RFC',
+          citation: 'RFC 7519',
+          url: 'https://www.rfc-editor.org/rfc/rfc7519',
+          normative: true,
+        },
+      ],
+      mappings: {},
+    };
+    const kinds = deriveSourceKinds(jwt);
+    expect(kinds).toContain('RFC');
+    const type = deriveTypeCategory(jwt.term, jwt.tags, jwt.mappings);
+    expect(type).toBe('identity'); // consistent heuristic choice
+  });
+
+  it('XSS (CWE+CAPEC) → kinds include CWE and CAPEC; typeCategory vulnerability', () => {
+    const xss = {
+      term: 'Cross-Site Scripting',
+      tags: ['appsec', 'web', 'cwe', 'capec'],
+      sources: [
+        {
+          kind: 'CWE',
+          citation: 'CWE-79',
+          url: 'https://cwe.mitre.org/data/definitions/79.html',
+          normative: true,
+        },
+        {
+          kind: 'CAPEC',
+          citation: 'CAPEC-63',
+          url: 'https://capec.mitre.org/data/definitions/63.html',
+          normative: true,
+        },
+      ],
+      mappings: { cweIds: ['CWE-79'], capecIds: ['CAPEC-63'] },
+    };
+    const kinds = deriveSourceKinds(xss);
+    expect(kinds).toEqual(expect.arrayContaining(['CWE', 'CAPEC']));
+    const type = deriveTypeCategory(xss.term, xss.tags, xss.mappings);
+    expect(type).toBe('vulnerability');
+  });
+
+  it('AiTM (CAPEC) → kinds include CAPEC; typeCategory attack-pattern', () => {
+    const aitm = {
+      term: 'Adversary-in-the-Middle',
+      tags: ['network', 'capec'],
+      sources: [
+        {
+          kind: 'CAPEC',
+          citation: 'CAPEC-94',
+          url: 'https://capec.mitre.org/data/definitions/94.html',
+          normative: true,
+        },
+      ],
+      mappings: { capecIds: ['CAPEC-94'] },
+    };
+    const kinds = deriveSourceKinds(aitm);
+    expect(kinds).toEqual(expect.arrayContaining(['CAPEC']));
+    const type = deriveTypeCategory(aitm.term, aitm.tags, aitm.mappings);
+    expect(type).toBe('attack-pattern');
+  });
+
+  it('TLS (RFC) → typeCategory protocol', () => {
+    const tls = {
+      term: 'Transport Layer Security',
+      tags: ['crypto', 'network', 'rfc', 'protocol'],
+      sources: [
+        {
+          kind: 'RFC',
+          citation: 'RFC 8446',
+          url: 'https://www.rfc-editor.org/rfc/rfc8446',
+          normative: true,
+        },
+      ],
+      mappings: {},
+    };
+    const kinds = deriveSourceKinds(tls);
+    expect(kinds).toContain('RFC');
+    const type = deriveTypeCategory(tls.term, tls.tags, tls.mappings);
+    expect(type).toBe('protocol');
+  });
+});

--- a/tests/unit/search-synonyms.test.ts
+++ b/tests/unit/search-synonyms.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import MiniSearch from 'minisearch';
+import { buildIndexPayload } from '../../src/lib/searchBuild';
+import { normalizeTokens } from '../../src/lib/tokenize';
+
+describe('search: normalization and build-time synonyms', () => {
+  it('token normalization handles "/" and case variants', () => {
+    const t1 = normalizeTokens('HTTP/2');
+    expect(t1).toContain('http2');
+    expect(t1).toContain('http');
+    expect(t1).toContain('2');
+
+    const t2 = normalizeTokens('DoS');
+    expect(t2).toContain('dos');
+  });
+
+  it('synonym expansion (jot → jwt, ssl → tls, mitm → aitm) at build time', () => {
+    const docs = [
+      {
+        id: 'jwt',
+        term: 'JSON Web Token',
+        acronym: ['JWT'],
+        aliases: [],
+        text: 'token',
+        tags: ['auth'],
+        sourceKinds: ['RFC'],
+      },
+      {
+        id: 'tls',
+        term: 'Transport Layer Security',
+        acronym: ['TLS'],
+        aliases: [],
+        text: 'protocol',
+        tags: ['crypto'],
+        sourceKinds: ['RFC'],
+      },
+      {
+        id: 'aitm',
+        term: 'Adversary-in-the-Middle',
+        acronym: ['AiTM'],
+        aliases: [],
+        text: 'attack pattern',
+        tags: ['network'],
+        sourceKinds: ['CAPEC'],
+      },
+    ];
+    const payload = buildIndexPayload(docs as any);
+    const mini = MiniSearch.loadJSON(payload.index as string, payload.options as any);
+
+    const r1 = mini.search('jot', payload.options.searchOptions);
+    expect(r1.some((r: any) => r.id === 'jwt')).toBe(true);
+
+    const r2 = mini.search('ssl', payload.options.searchOptions);
+    expect(r2.some((r: any) => r.id === 'tls')).toBe(true);
+
+    const r3 = mini.search('mitm', payload.options.searchOptions);
+    expect(r3.some((r: any) => r.id === 'aitm')).toBe(true);
+  });
+
+  it('de-duplication: single doc returned even if alias/title overlap', () => {
+    const docs = [
+      {
+        id: 'jwt',
+        term: 'JSON Web Token',
+        acronym: ['JWT'],
+        aliases: ['JWT Token'],
+        text: 'token',
+        tags: ['auth'],
+        sourceKinds: ['RFC'],
+      },
+    ];
+    const payload = buildIndexPayload(docs as any);
+    const mini = MiniSearch.loadJSON(payload.index as string, payload.options as any);
+
+    const r = mini.search('jwt token', payload.options.searchOptions);
+    const ids = r.map((x: any) => x.id);
+    // Ensure only one entry for jwt
+    expect(ids.filter((id: string) => id === 'jwt').length).toBe(1);
+  });
+
+  it('scoring: exact title/id outranks alias-only matches; deterministic tie-break by slug', () => {
+    // tls has alias "ssl" via synonyms.json; add a real ssl doc too — exact title/id should outrank alias
+    const docs = [
+      {
+        id: 'tls',
+        term: 'Transport Layer Security',
+        acronym: ['TLS'],
+        aliases: [],
+        text: 'crypto protocol',
+        tags: ['crypto', 'protocol'],
+        sourceKinds: ['RFC'],
+      },
+      {
+        id: 'ssl',
+        term: 'Secure Sockets Layer',
+        acronym: ['SSL'],
+        aliases: [],
+        text: 'legacy protocol',
+        tags: ['protocol'],
+        sourceKinds: ['RFC'],
+      },
+    ];
+    const payload = buildIndexPayload(docs as any);
+    const mini = MiniSearch.loadJSON(payload.index as string, payload.options as any);
+
+    const r = mini.search('ssl', payload.options.searchOptions);
+    // Expect SSL doc (exact) above TLS (matched via alias)
+    expect((r[0] as any).id).toBe('ssl');
+    // Deterministic order for remainder by score then slug
+    for (let i = 1; i < r.length; i++) {
+      expect(typeof (r[i] as any).id).toBe('string');
+    }
+  });
+});


### PR DESCRIPTION
Scope: PR3 only. Build-time synonyms/alias expansion and facet filters (source/type/tags) with deterministic ranking and accessible UI. CSP remains strict and JS budget on "/" unchanged.

Rationale
- Deterministic search behavior with canonical alias graph at build time, avoiding client payload bloat and runtime ambiguity
- Faceted filtering (Sources, Types, Tags) enables shareable state and consistent server/client behavior

Implementation
- Build-time synonyms
  - Canonical map: [src/search/synonyms.json](src/search/synonyms.json)
  - Token normalization helper: [src/lib/tokenize.ts](src/lib/tokenize.ts)
  - Index build enrichment (no extra docs; only token vocab expansion): [src/lib/searchBuild.ts](src/lib/searchBuild.ts)
    - Highest boost: id/title tokens; medium: aliasTokens; lower: text/tags
    - Deterministic tie-break by slug
  - Shared MiniSearch options: [src/lib/searchOptions.ts](src/lib/searchOptions.ts)

- Facets derivation
  - Helpers: [src/lib/facets.ts](src/lib/facets.ts)
    - sourceKinds: derives NIST/ATTACK/CWE/CAPEC/RFC from sources/mappings/URLs
    - typeCategory: protocol | vulnerability | attack-pattern | crypto | identity | concept
  - Emitted payload: minimal fields only (id, term, acronym, tags, sourceKinds, typeCategory, aliasTokens); plus a small tags meta list
  - Endpoint updated: [src/pages/search.json.ts](src/pages/search.json.ts)

- Client UX
  - URL state (q, sources, types, tags) parse/serialize; unknown params preserved: [src/scripts/searchClient.ts](src/scripts/searchClient.ts)
  - Filtering (AND within facet groups; AND across groups) with deterministic stable order
  - "Alias match" badge shown when match is driven solely by aliasTokens
  - Accessible controls with aria-labels and keyboard navigation; live region preserved
  - UI controls: [src/components/Search.astro](src/components/Search.astro)

- Tests
  - Unit: synonyms, normalization, dedup, scoring: [tests/unit/search-synonyms.test.ts](tests/unit/search-synonyms.test.ts)
  - Unit: facets derivation: [tests/unit/search-facets.test.ts](tests/unit/search-facets.test.ts)
  - Integration: combined filters: [tests/unit/search-combinedFilters.test.ts](tests/unit/search-combinedFilters.test.ts)
  - E2E: alias badge, combined filters, URL state, keyboard-only: updated [tests/e2e/search-filters.spec.ts](tests/e2e/search-filters.spec.ts)

Performance & Security
- Synonyms expansion is build-time only; no client import of synonyms.json
- /search.json remains lean (no heavy source/mappings objects); adds only small facet fields
- CSP remains strict (no inline scripts/styles added)
- JS budget on "/" remains within Lighthouse budgets; no material increase observed

Validation
- Validated locally: npm run typecheck, npm run lint, npm run test — all pass
- verify-merged scripts remain unaffected

Labels (request): feature, search, a11y, tests

Notes
- Behavior stable after reload/share via URL state
- Deterministic ranking maintained; no duplicates in results