### PR TITLE
fix(etl): deterministic NIST fallback + ci(lighthouse): enforce budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - run: npm run lint -- --max-warnings=0
       - run: npm run build
 
-      # Enforce Lighthouse budgets using lighthouse/budgets.json
+      # Enforce Lighthouse budgets (source of truth: lighthouse/budgets.json)
       - name: Check Lighthouse budgets
         run: npm run lh:preview
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,20 @@ jobs:
       - run: npm run typecheck
       - run: npm run lint -- --max-warnings=0
       - run: npm run build
+
+      # Enforce Lighthouse budgets using lighthouse/budgets.json
+      - name: Check Lighthouse budgets
+        run: npm run lh:preview
+
+      - name: Upload Lighthouse preview artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-preview
+          path: |
+            lighthouse/*.json
+            lighthouse/*.html
+            .lighthouse/**
+
       - run: npx playwright install --with-deps
       - run: npm run test:offline

--- a/.github/workflows/etl-refresh.yml
+++ b/.github/workflows/etl-refresh.yml
@@ -20,6 +20,8 @@ env:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    env:
+      TZ: UTC
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4 pinned

--- a/.github/workflows/etl-refresh.yml
+++ b/.github/workflows/etl-refresh.yml
@@ -43,7 +43,7 @@ jobs:
             etl-raw-
 
       - name: Install dependencies
-        run: npm ci
+        run: NODE_ENV='' npm ci --ignore-scripts
 
       - name: Run ETL (vendors)
         run: npm run etl:all

--- a/.github/workflows/etl-refresh.yml
+++ b/.github/workflows/etl-refresh.yml
@@ -45,7 +45,8 @@ jobs:
             etl-raw-
 
       - name: Install dependencies
-        run: NODE_ENV='' npm ci --ignore-scripts
+        # Allow lifecycle scripts to run but disable Husky specifically to avoid hook failures in CI
+        run: HUSKY=0 npm ci
 
       - name: Run ETL (vendors)
         run: npm run etl:all
@@ -58,6 +59,11 @@ jobs:
         run: |
           set -e
           npm run etl:verify | tee verify-summary.txt
+
+      - name: Report NIST fallback usage
+        if: always()
+        run: |
+          node -e "const fs=require('fs');let out;try{const m=JSON.parse(fs.readFileSync('data/raw/nist/meta.json','utf8')); out = m.usedFallback ? \`usedFallback=true source=\${m.fallbackSource||'unknown'} entries=\${m.count}\` : 'usedFallback=false'; } catch(e){ out='usedFallback=unknown error='+e.message } fs.writeFileSync('etl-fallback.txt', out); if(out.startsWith('usedFallback=true')) console.log('::warning::NIST ETL used fallback: ' + out); else console.log('NIST ETL used upstream');"
 
       - name: Typecheck
         id: typecheck

--- a/.github/workflows/etl-refresh.yml
+++ b/.github/workflows/etl-refresh.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TZ: UTC
+      ETL_ENABLE_AUTOPR: ${{ vars.ETL_ENABLE_AUTOPR || 'false' }}
+      ETL_ALLOW_FALLBACK: 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4 pinned
@@ -120,8 +122,22 @@ jobs:
             echo "Validated: verify-merged passed; typecheck/lint/test executed."
           } > pr-body.md
 
+      - name: Detect data changes
+        id: changes
+        run: |
+          if git status --porcelain -- data | grep .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Auto-PR disabled
+        if: ${{ env.ETL_ENABLE_AUTOPR != 'true' }}
+        run: echo "auto-PR disabled (ETL_ENABLE_AUTOPR != 'true'); build/verify ran; fallback preserved"
+
+      # Note: Some repositories restrict GITHUB_TOKEN from creating PRs; this step is opt-in via ETL_ENABLE_AUTOPR
       - name: Create Pull Request with changes under data/
-        if: ${{ success() }}
+        if: ${{ env.ETL_ENABLE_AUTOPR == 'true' && steps.changes.outputs.changed == 'true' }}
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6 pinned
         with:
           commit-message: 'ci(etl): refresh vendor datasets and merged index'

--- a/.github/workflows/etl-refresh.yml
+++ b/.github/workflows/etl-refresh.yml
@@ -137,6 +137,10 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Notify when data changed but auto-PR disabled
+        if: ${{ env.ETL_ENABLE_AUTOPR != 'true' && steps.changes.outputs.changed == 'true' }}
+        run: echo "::warning::Data changed under 'data/' but auto-PR is disabled (ETL_ENABLE_AUTOPR != 'true'). Please commit and open a PR manually."
+
       - name: Auto-PR disabled
         if: ${{ env.ETL_ENABLE_AUTOPR != 'true' }}
         run: echo "auto-PR disabled (ETL_ENABLE_AUTOPR != 'true'); build/verify ran; fallback preserved"

--- a/scripts/lh_preview.sh
+++ b/scripts/lh_preview.sh
@@ -33,7 +33,8 @@ for i in $(seq 1 $ATTEMPTS); do
 done
 
 echo "[lh_preview] Running Lighthouse budgets..."
-npx -y lighthouse http://localhost:4321 --quiet --chrome-flags='--headless=new' --budgets-path=./lighthouse/budgets.json --only-categories=performance --preset=desktop --no-enable-error-reporting
+# Save both JSON and HTML reports under ./lighthouse for CI artifact upload
+npx -y lighthouse http://localhost:4321 --quiet --chrome-flags='--headless=new' --budgets-path=./lighthouse/budgets.json --only-categories=performance --preset=desktop --no-enable-error-reporting --output=json --output=html --output-path=lighthouse/preview
 CODE=$?
 
 echo "[lh_preview] Stopping preview (PID: $PREVIEW_PID)..."


### PR DESCRIPTION
Summary
- Stabilize NIST ETL with deterministic fallback when upstream is empty/invalid
  - scripts/fetch-nist.mjs: add ALLOW_FALLBACK (env: ETL_ALLOW_FALLBACK, default "true"), reuse cached raw/consolidated artifacts, trim/dedupe/sort by slug to keep output deterministic.
  - No changes to scripts/verify-merged.mjs.
- Deterministic CI environment
  - .github/workflows/etl-refresh.yml: set TZ: UTC to avoid time drift.
- Enforce Lighthouse budgets in CI
  - .github/workflows/ci.yml: run `npm run lh:preview` and upload artifacts; budgets governed by lighthouse/budgets.json.
  - scripts/lh_preview.sh: emit JSON+HTML reports under ./lighthouse for artifact collection.

Notes
- Fallback is conservative and only used when forced refresh returns empty/invalid; behavior controlled via ETL_ALLOW_FALLBACK (set to false to fail-fast).
- Budgets remain unchanged and will fail CI on regressions.

## Summary by Sourcery

Implement a deterministic NIST ETL fallback and strengthen CI by enforcing Lighthouse budgets and ensuring reproducible, conditional data refreshes

New Features:
- Add deterministic fallback mechanism for NIST ETL to reuse cached datasets when upstream data is empty or invalid
- Enforce Lighthouse performance budgets in CI by running lh:preview and uploading JSON/HTML artifacts

Enhancements:
- Normalize, dedupe, and sort NIST fragments for stable, deterministic outputs
- Report NIST fallback usage in the ETL refresh workflow and fix timezone to UTC to avoid time drift
- Disable Husky in ETL refresh, detect data changes before auto-PR, and conditionally enable pull request creation
- Update lh_preview.sh to output both JSON and HTML Lighthouse reports under ./lighthouse

CI:
- Set TZ=UTC, ETL_ALLOW_FALLBACK, and disable Husky in the ETL refresh workflow with a step to report fallback usage and conditional PR creation
- Add a CI workflow step to check Lighthouse budgets and upload preview artifacts