### PR TITLE
chore(docs): add security.txt and README pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ This repository now contains the v0.1.0 foundations: Astro + TS strict + MDX + C
 
 Recommended Node: 20 or 22 LTS to avoid engine warnings with Astro/Vite ecosystem.
 
+## Security and Contact
+
+- Security.txt: [/.well-known/security.txt](/.well-known/security.txt)
+- Report a vulnerability via GitHub Security Advisories: https://github.com/amanthanvi/synac/security/advisories/new
+- For uptime/debug probes, see [/healthz](/healthz) (source: [public/healthz/index.html](public/healthz/index.html); served as /healthz in production)
 ## Security & CSP
 
 - Strict CSP posture: no inline scripts or inline styles

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: https://github.com/amanthanvi/synac/security/advisories
+Preferred-Languages: en
+Expires: 2026-12-31T23:59:59Z
+Policy: https://github.com/amanthanvi/synac#security-and-contact

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,4 +1,7 @@
 Contact: https://github.com/amanthanvi/synac/security/advisories
+Encryption: https://github.com/amanthanvi.gpg
 Preferred-Languages: en
-Expires: 2026-12-31T23:59:59Z
 Policy: https://github.com/amanthanvi/synac#security-and-contact
+Scope: https://synac-production.up.railway.app/
+Scope: https://github.com/amanthanvi/synac
+Expires: 2026-12-31T23:59:59Z


### PR DESCRIPTION
Scope: Implement PR8 only. Add a public security.txt for coordinated disclosure and a README pointer. No code, runtime, CI, or policy changes. CSP and Lighthouse budgets unchanged.

Files changed:
- public/.well-known/security.txt
- README.md (new "Security and Contact" section)

security.txt (RFC 9116 minimal fields):
- Contact: https://github.com/amanthanvi/synac/security/advisories
- Preferred-Languages: en
- Expires: 2026-12-31T23:59:59Z
- Policy: https://github.com/amanthanvi/synac#security-and-contact

Verification after deploy:
```bash
curl -sS https://synac-production.up.railway.app/.well-known/security.txt
```

Notes:
- Build preview unchanged; budgets/determinism unaffected.
- Primary channel is GitHub Security Advisories (no private emails).

Direct file views on this branch:
- security.txt: https://github.com/amanthanvi/synac/blob/feat/pr8-securitytxt-readme/public/.well-known/security.txt
- README section: https://github.com/amanthanvi/synac/blob/feat/pr8-securitytxt-readme/README.md#security-and-contact

Commits:
- docs(security): add .well-known/security.txt
- docs(readme): add Security and Contact pointer

## Summary by Sourcery

Provide a public security.txt for coordinated disclosure and add a README section linking to it and the vulnerability reporting channel

Documentation:
- Add public/.well-known/security.txt containing contact, preferred languages, expiry, and policy fields per RFC 9116
- Add 'Security and Contact' section in README linking to security.txt, GitHub Security Advisories reporting URL, and health check endpoint