### PR TITLE
docs(ui): homepage intro + static “Popular searches” chips (CSP-safe, no JS)

### DIFF
--- a/src/lib/popularSearches.ts
+++ b/src/lib/popularSearches.ts
@@ -1,0 +1,19 @@
+export type PopularItem = {
+  label: string;
+  q: string;
+  sources?: string;
+  types?: string;
+};
+
+export const popularSearches: PopularItem[] = [
+  { label: 'TLS', q: 'tls', sources: 'RFC', types: 'protocol' },
+  { label: 'JWT', q: 'jwt', sources: 'RFC' },
+  { label: 'OAuth 2.0', q: 'oauth2' },
+  { label: 'XSS', q: 'xss', types: 'vulnerability' },
+  { label: 'mTLS', q: 'mtls', types: 'protocol' },
+  { label: 'QUIC', q: 'quic', types: 'protocol' },
+  { label: 'PKI', q: 'pki' },
+  { label: 'X.509', q: 'x509' },
+  { label: 'DoS', q: 'dos', types: 'vulnerability' },
+  { label: 'CSRF', q: 'csrf', types: 'vulnerability' },
+];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,11 +2,23 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
 import Search from '../components/Search.astro';
+import { popularSearches } from '../lib/popularSearches';
+import type { PopularItem } from '../lib/popularSearches';
 
 const seeds = await getCollection('terms');
 const seedList = seeds
 	.filter((e) => ['syn', 'ack', 'pki', 'tls', 'xss', 'zero-trust'].includes(e.slug))
 	.sort((a, b) => a.slug.localeCompare(b.slug));
+
+/** PR9 review: popular chips sourced from shared data module (src/lib/popularSearches.ts) */
+
+const hrefFor = (p: PopularItem) => {
+	const parts: string[] = [`q=${encodeURIComponent(p.q)}`];
+	if (p.sources) parts.push(`sources=${encodeURIComponent(p.sources)}`);
+	if (p.types) parts.push(`types=${encodeURIComponent(p.types)}`);
+	// Join with & to keep HTML valid; browsers interpret & as & in URLs.
+	return `/?${parts.join('&')}`;
+};
 ---
 
 <BaseLayout title="SynAc">
@@ -25,18 +37,15 @@ const seedList = seeds
 	</section>
 
 	<section class="popular" aria-labelledby="popular-heading">
-		<h3 id="popular-heading">Popular searches</h3>
+		<h2 id="popular-heading">Popular searches</h2>
 		<nav class="chips" aria-label="Popular searches">
-			<a class="btn-chip" href="/?q=tls&sources=RFC&types=protocol">TLS</a>
-			<a class="btn-chip" href="/?q=jwt&sources=RFC">JWT</a>
-			<a class="btn-chip" href="/?q=oauth2">OAuth 2.0</a>
-			<a class="btn-chip" href="/?q=xss&types=vulnerability">XSS</a>
-			<a class="btn-chip" href="/?q=mtls&types=protocol">mTLS</a>
-			<a class="btn-chip" href="/?q=quic&types=protocol">QUIC</a>
-			<a class="btn-chip" href="/?q=pki">PKI</a>
-			<a class="btn-chip" href="/?q=x509">X.509</a>
-			<a class="btn-chip" href="/?q=dos&types=vulnerability">DoS</a>
-			<a class="btn-chip" href="/?q=csrf&types=vulnerability">CSRF</a>
+			{
+				popularSearches.map((p: PopularItem) => (
+					<a class="btn-chip" href={hrefFor(p)}>
+						{p.label}
+					</a>
+				))
+			}
 		</nav>
 	</section>
 


### PR DESCRIPTION
Scope: Implement PR9 only. Adds a brief homepage introduction and a static “Popular searches” chip row using pure HTML.

File changed:
- [src/pages/index.astro](src/pages/index.astro)
  - Inserted introduction section near the top of the main content, above the search UI:
    <section class="intro" aria-labelledby="about-heading">
      <h2 id="about-heading">What is SynAc?</h2>
      <p>SynAc is a source‑anchored cybersecurity glossary. It provides concise, evidence‑first definitions with provenance (NIST, RFCs, MITRE), offline‑capable deterministic search, and strict security posture.</p>
    </section>
  - Inserted static “Popular searches” section using semantic nav and existing chip styles (chip container .chips and chip .btn-chip classes) with URL parameter links (q, sources, types):
    <section class="popular" aria-labelledby="popular-heading">
      <h3 id="popular-heading">Popular searches</h3>
      <nav class="chips" aria-label="Popular searches">
        <a class="btn-chip" href="/?q=tls&amp;sources=RFC&amp;types=protocol">TLS</a>
        <a class="btn-chip" href="/?q=jwt&amp;sources=RFC">JWT</a>
        <a class="btn-chip" href="/?q=oauth2">OAuth 2.0</a>
        <a class="btn-chip" href="/?q=xss&amp;types=vulnerability">XSS</a>
        <a class="btn-chip" href="/?q=mtls&amp;types=protocol">mTLS</a>
        <a class="btn-chip" href="/?q=quic&amp;types=protocol">QUIC</a>
        <a class="btn-chip" href="/?q=pki">PKI</a>
        <a class="btn-chip" href="/?q=x509">X.509</a>
        <a class="btn-chip" href="/?q=dos&amp;types=vulnerability">DoS</a>
        <a class="btn-chip" href="/?q=csrf&amp;types=vulnerability">CSRF</a>
      </nav>
    </section>

Constraints honored:
- No JavaScript additions; no changes to search ranking or payload
- Strict CSP preserved (HTML-only change; no inline styles/scripts)
- Budgets unchanged; deterministic build unaffected
- No modifications to [src/lib/searchBuild.ts](src/lib/searchBuild.ts:1) or [src/pages/search.json.ts](src/pages/search.json.ts:1)

Validation (local):
- npm run typecheck — OK
- npm run lint — OK
- npm run test (unit) — OK

Notes:
- Reused existing chip styles from [src/ui/tokens.css](src/ui/tokens.css:314) via container .chips and .btn-chip classes for 44px tap targets and visible focus.
- Existing URL state parsing covers the anchors (q, sources, types), aligning with e2e/search coverage.

## Summary by Sourcery

Add a homepage introduction section and a static "Popular searches" chip navigation above the search UI using pure HTML and update documentation with security and contact information.

New Features:
- Add homepage introduction section describing SynAc
- Add static "Popular searches" chip navigation with preset query links, using existing CSS classes

Documentation:
- Update README with security and contact information
- Add security.txt at /.well-known/security.txt