### PR TITLE
docs(terms): curated content batch (citations + mappings)

### DIFF
--- a/src/content/terms/coep.mdx
+++ b/src/content/terms/coep.mdx
@@ -1,0 +1,13 @@
+---
+id: 'coep'
+term: 'Cross‑Origin Embedder Policy (COEP)'
+summary: 'Response header requiring cross‑origin resources to opt‑in to being embedded, enabling powerful APIs with isolation.'
+tags: ['web', 'security', 'headers']
+sources:
+  - kind: 'OTHER'
+    citation: 'HTML/FETCH — Cross‑Origin Embedder Policy'
+    url: 'https://html.spec.whatwg.org/multipage/browsers.html#coep'
+    normative: true
+updatedAt: '2025-09-07T00:00:00.000Z'
+---
+COEP requires CORP or CORS on embedded resources, supporting cross‑origin isolation.

--- a/src/content/terms/coop.mdx
+++ b/src/content/terms/coop.mdx
@@ -1,0 +1,13 @@
+---
+id: 'coop'
+term: 'Cross‑Origin Opener Policy (COOP)'
+summary: 'Response header that isolates a browsing context from cross‑origin windows, mitigating cross‑origin side‑channel risks.'
+tags: ['web', 'security', 'headers']
+sources:
+  - kind: 'OTHER'
+    citation: 'HTML Standard — Cross‑Origin Opener Policy'
+    url: 'https://html.spec.whatwg.org/multipage/browsers.html#cross-origin-opener-policies'
+    normative: true
+updatedAt: '2025-09-07T00:00:00.000Z'
+---
+COOP enforces process isolation for top‑level documents using values like same‑origin to reduce interference.

--- a/src/content/terms/corp.mdx
+++ b/src/content/terms/corp.mdx
@@ -1,0 +1,13 @@
+---
+id: 'corp'
+term: 'Cross‑Origin Resource Policy (CORP)'
+summary: 'Response header that declares a resource’s embeddability by cross‑origin documents.'
+tags: ['web', 'security', 'headers']
+sources:
+  - kind: 'OTHER'
+    citation: 'Fetch Standard — CORP'
+    url: 'https://fetch.spec.whatwg.org/#corp'
+    normative: true
+updatedAt: '2025-09-07T00:00:00.000Z'
+---
+CORP controls cross‑origin embedding to reduce data exposure.

--- a/src/content/terms/cors.mdx
+++ b/src/content/terms/cors.mdx
@@ -1,0 +1,16 @@
+---
+id: 'cors'
+term: 'Cross-Origin Resource Sharing (CORS)'
+summary: 'Mechanism where servers opt in to cross-origin requests via HTTP headers, enforcing origin-based access controls.'
+tags: ['web', 'security', 'headers']
+sources:
+  - kind: 'OTHER'
+    citation: 'WHATWG Fetch Standard — CORS'
+    url: 'https://fetch.spec.whatwg.org/#http-cors-protocol'
+    normative: true
+  - kind: 'OTHER'
+    citation: 'W3C CORS (historical)'
+    url: 'https://www.w3.org/TR/cors/'
+updatedAt: '2025-09-07T00:00:00.000Z'
+---
+CORS augments the SOP by defining preflight and response headers that explicitly permit cross‑origin requests.

--- a/src/content/terms/csp.mdx
+++ b/src/content/terms/csp.mdx
@@ -1,0 +1,16 @@
+---
+id: 'csp'
+term: 'Content Security Policy (CSP)'
+summary: 'HTTP response policy that restricts sources of active and passive content to mitigate XSS and related injection risks.'
+tags: ['web', 'security', 'headers']
+sources:
+  - kind: 'OTHER'
+    citation: 'W3C CSP Level 3'
+    url: 'https://www.w3.org/TR/CSP3/'
+    normative: true
+  - kind: 'OTHER'
+    citation: 'MDN: Content Security Policy (reference)'
+    url: 'https://developer.mozilla.org/docs/Web/HTTP/CSP'
+updatedAt: '2025-09-07T00:00:00.000Z'
+---
+CSP lets sites declare allowable content sources, blocking inline scripts and unauthorized origins to reduce injection risk.

--- a/src/content/terms/dot.mdx
+++ b/src/content/terms/dot.mdx
@@ -1,0 +1,13 @@
+---
+id: 'dot'
+term: 'DNS over TLS (DoT)'
+summary: 'Protocol for encrypting DNS queries using TLS to improve privacy and integrity between clients and resolvers.'
+tags: ['network', 'dns', 'rfc', 'privacy']
+sources:
+  - kind: 'RFC'
+    citation: 'RFC 7858 — DNS over TLS'
+    url: 'https://www.rfc-editor.org/rfc/rfc7858'
+    normative: true
+updatedAt: '2025-09-07T00:00:00.000Z'
+---
+DoT wraps DNS messages in TLS, authenticating resolvers and limiting on‑path observation or tampering.

--- a/src/content/terms/mfa.mdx
+++ b/src/content/terms/mfa.mdx
@@ -1,0 +1,13 @@
+---
+id: 'mfa'
+term: 'Multi‑Factor Authentication (MFA)'
+summary: 'Authentication requiring two or more distinct factors (knowledge, possession, inherence) to establish confidence in identities.'
+tags: ['auth', 'identity', 'nist']
+sources:
+  - kind: 'NIST'
+    citation: 'NIST SP 800‑63B'
+    url: 'https://pages.nist.gov/800-63-3/sp800-63b.html'
+    normative: true
+updatedAt: '2025-09-07T00:00:00.000Z'
+---
+MFA combines independent authenticators to reduce risk from single‑factor compromise.

--- a/src/content/terms/passkeys.mdx
+++ b/src/content/terms/passkeys.mdx
@@ -1,0 +1,16 @@
+---
+id: 'passkeys'
+term: 'Passkeys'
+summary: 'FIDO‑based, phishing‑resistant credentials built on WebAuthn, syncing across devices or backed by roaming authenticators.'
+tags: ['auth', 'identity', 'web']
+sources:
+  - kind: 'OTHER'
+    citation: 'FIDO Alliance — Passkeys'
+    url: 'https://fidoalliance.org/passkeys/'
+  - kind: 'OTHER'
+    citation: 'W3C WebAuthn Level 2'
+    url: 'https://www.w3.org/TR/webauthn-2/'
+    normative: true
+updatedAt: '2025-09-07T00:00:00.000Z'
+---
+Passkeys use asymmetric keys to replace passwords, with device or cloud‑mediated credential storage.

--- a/src/content/terms/referrer-policy.mdx
+++ b/src/content/terms/referrer-policy.mdx
@@ -1,0 +1,13 @@
+---
+id: 'referrer-policy'
+term: 'Referrer-Policy'
+summary: 'Response header controlling the Referer information sent with requests to enhance privacy and reduce leakage.'
+tags: ['web', 'privacy', 'headers']
+sources:
+  - kind: 'OTHER'
+    citation: 'W3C Referrer Policy'
+    url: 'https://www.w3.org/TR/referrer-policy/'
+    normative: true
+updatedAt: '2025-09-07T00:00:00.000Z'
+---
+Referrer‑Policy values restrict the Referer header sent to destinations, such as strict‑origin‑when‑cross‑origin.

--- a/src/content/terms/same-origin-policy.mdx
+++ b/src/content/terms/same-origin-policy.mdx
@@ -1,0 +1,13 @@
+---
+id: 'same-origin-policy'
+term: 'Same‑Origin Policy (SOP)'
+summary: 'Browser security model that restricts documents or scripts from different origins from interacting with each other.'
+tags: ['web', 'security']
+sources:
+  - kind: 'RFC'
+    citation: 'RFC 6454 — The Web Origin Concept'
+    url: 'https://www.rfc-editor.org/rfc/rfc6454'
+    normative: true
+updatedAt: '2025-09-07T00:00:00.000Z'
+---
+SOP limits DOM access and data sharing across origins, forming the baseline for web isolation.

--- a/src/content/terms/sso.mdx
+++ b/src/content/terms/sso.mdx
@@ -1,0 +1,13 @@
+---
+id: 'sso'
+term: 'Single Sign‑On (SSO)'
+summary: 'A federation pattern enabling users to authenticate once and obtain access to multiple relying parties through an identity provider.'
+tags: ['auth', 'identity', 'federation']
+sources:
+  - kind: 'NIST'
+    citation: 'NIST SP 800‑63C (Federation)'
+    url: 'https://pages.nist.gov/800-63-3/sp800-63c.html'
+    normative: true
+updatedAt: '2025-09-07T00:00:00.000Z'
+---
+SSO uses federation protocols to convey identity assertions across trust boundaries.

--- a/src/content/terms/webauthn.mdx
+++ b/src/content/terms/webauthn.mdx
@@ -1,0 +1,13 @@
+---
+id: 'webauthn'
+term: 'Web Authentication (WebAuthn)'
+summary: 'A W3C standard enabling public‑key authentication in browsers with authenticators (platform or roaming).'
+tags: ['auth', 'web', 'identity']
+sources:
+  - kind: 'OTHER'
+    citation: 'W3C WebAuthn Level 2'
+    url: 'https://www.w3.org/TR/webauthn-2/'
+    normative: true
+updatedAt: '2025-09-07T00:00:00.000Z'
+---
+WebAuthn establishes phishing‑resistant authentication using key pairs scoped to relying parties.


### PR DESCRIPTION
Scope and constraints
- docs-only content; no runtime changes to features; CSP/budgets/determinism posture preserved

Terms added (12) with sources/mappings
1) Content Security Policy (CSP)
   - Sources: W3C CSP Level 3 (normative), MDN reference (informative)
   - File: src/content/terms/csp.mdx

2) Cross-Origin Resource Sharing (CORS)
   - Sources: WHATWG Fetch — CORS (normative), W3C CORS (historical; informative)
   - File: src/content/terms/cors.mdx

3) Multi-Factor Authentication (MFA)
   - Source: NIST SP 800-63B (normative)
   - File: src/content/terms/mfa.mdx

4) Single Sign-On (SSO)
   - Source: NIST SP 800-63C (normative)
   - File: src/content/terms/sso.mdx

5) DNS over TLS (DoT)
   - Source: RFC 7858 (normative)
   - File: src/content/terms/dot.mdx

6) Web Authentication (WebAuthn)
   - Source: W3C WebAuthn Level 2 (normative)
   - File: src/content/terms/webauthn.mdx

7) Passkeys
   - Sources: FIDO Alliance — Passkeys (informative), W3C WebAuthn Level 2 (normative)
   - File: src/content/terms/passkeys.mdx

8) Cross-Origin Opener Policy (COOP)
   - Source: HTML Standard — COOP (normative)
   - File: src/content/terms/coop.mdx

9) Cross-Origin Embedder Policy (COEP)
   - Source: HTML/Fetch — COEP (normative)
   - File: src/content/terms/coep.mdx

10) Cross-Origin Resource Policy (CORP)
   - Source: Fetch Standard — CORP (normative)
   - File: src/content/terms/corp.mdx

11) Referrer-Policy
   - Source: W3C Referrer Policy (normative)
   - File: src/content/terms/referrer-policy.mdx

12) Same-Origin Policy (SOP)
   - Source: RFC 6454 — The Web Origin Concept (normative)
   - File: src/content/terms/same-origin-policy.mdx

Files added
- src/content/terms/csp.mdx
- src/content/terms/cors.mdx
- src/content/terms/mfa.mdx
- src/content/terms/sso.mdx
- src/content/terms/dot.mdx
- src/content/terms/webauthn.mdx
- src/content/terms/passkeys.mdx
- src/content/terms/coop.mdx
- src/content/terms/coep.mdx
- src/content/terms/corp.mdx
- src/content/terms/referrer-policy.mdx
- src/content/terms/same-origin-policy.mdx

Validation (local)
- typecheck: OK
- lint: OK
- unit tests: OK
- build: OK
- Lighthouse budgets (lh:preview): OK (green)

Notes
- Content aligns with src/content/schema.ts (term, tags, sources with kind/citation/url/normative, updatedAt ISO). Bodies are concise and evidence-first with normative citations where applicable.
- This PR contains only authored content under src/content/terms. No app/runtime behavior changed.

## Summary by Sourcery

Enforce comprehensive security headers, introduce a versioned health endpoint, refine citation sanitization, enhance landing page styling, update documentation, and batch-add 12 security and web protocol term definitions.

New Features:
- Apply strict security headers to all server responses
- Add a JSON/HEAD /healthz endpoint exposing status, uptime, version, and commitSha
- Load package.json version at startup for use in health endpoint

Enhancements:
- Refine citation sanitization to replace control characters with spaces
- Add landing page section spacing and chip layout CSS
- Document security headers and health endpoint details in README

CI:
- Inject COMMIT_SHA env var and add CI step to verify security headers and /healthz endpoint, uploading diagnostics artifacts

Documentation:
- Add 12 curated term definitions (CSP, CORS, MFA, SSO, DoT, WebAuthn, Passkeys, COOP, COEP, CORP, Referrer-Policy, SOP) with normative and informative citations