### PR TITLE
chore(dev): refine lint-staged for MDX; docs(healthz): document COMMIT_SHA

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,10 +67,7 @@
       "eslint --max-warnings=0 --no-warn-ignored --fix",
       "prettier --write"
     ],
-    "src/content/**/*.mdx": [
-      "prettier --write"
-    ],
-    "*.mdx": [
+    "**/*.mdx": [
       "prettier --write"
     ]
   }


### PR DESCRIPTION
Summary
- Prevent pre-commit failures on MDX content by excluding MDX from ESLint in lint-staged, while keeping Prettier on MDX.
- Document how to surface commitSha in production /healthz via COMMIT_SHA env variable on Railway.

Changes
- lint-staged: Only run ESLint (with --no-warn-ignored) for *.{ts,tsx,js,jsx,astro}; run Prettier for *.mdx and src/content/**/*.mdx (no ESLint on MDX) in [package.json](package.json:65).
- README: Clarify /healthz fields and how to set COMMIT_SHA in prod in [README.md](README.md:329).

Rationale
- Husky pre-commit previously aborted due to ESLint warnings for ignored MDX files. This change keeps MDX formatting (Prettier) and stops ESLint from blocking content-only commits.
- COMMIT_SHA exposure is optional; CI already injects it for preview checks. Docs now explain how to set it in Railway if desired.
