### PR TITLE
feat(search-ui): show matched alias text in result badge

### DIFF
--- a/src/scripts/searchClient.ts
+++ b/src/scripts/searchClient.ts
@@ -131,7 +131,8 @@ declare global {
       if (it.matchedViaAlias) {
         const ab = document.createElement('span');
         ab.className = 'badge';
-        ab.textContent = 'Alias match';
+        const alias = typeof it.matchedAlias === 'string' ? it.matchedAlias : '';
+        ab.textContent = alias ? `Matched via alias '${alias}'` : 'Alias match';
         const sr = document.createElement('span');
         sr.className = 'sr-only';
         sr.textContent = ' (matched via alias)';
@@ -356,11 +357,15 @@ declare global {
   const decorateAndFilter = (results: any[], qTokens: string[]): any[] => {
     const decorated = results.map((r: any) => {
       const aliasTokens: string[] = Array.isArray(r.aliasTokens) ? r.aliasTokens : [];
-      const aliasHit = aliasTokens.length ? aliasTokens.some((t) => qTokens.includes(t)) : false;
+      const matchedAliasToken = aliasTokens.find((t) => qTokens.includes(t));
       const idHit = normalizeTokens(String(r.id || '')).some((t) => qTokens.includes(t));
       const titleHit = normalizeTokens(String(r.term || '')).some((t) => qTokens.includes(t));
-      const matchedViaAlias = !!(aliasHit && !(idHit || titleHit));
-      return { ...r, matchedViaAlias };
+      const matchedViaAlias = !!(matchedAliasToken && !(idHit || titleHit));
+      return {
+        ...r,
+        matchedViaAlias,
+        matchedAlias: matchedViaAlias ? matchedAliasToken : undefined,
+      };
     });
     const sel: FacetSelections = {
       sources: Array.from(selectedSources),


### PR DESCRIPTION
Summary
- Render "Matched via alias '<alias>'" when a hit matched via alias token (and not id/title).
- Keep existing classes and sr-only span; use textContent for CSP/a11y; no new deps.

Changes
- Compute matchedAlias token and matchedViaAlias in decorateAndFilter; attach matchedAlias for rendering. [src/scripts/searchClient.ts](src/scripts/searchClient.ts)
- Update alias badge rendering to show actual token via textContent with sr-only suffix. [src/scripts/searchClient.ts](src/scripts/searchClient.ts)

Validation
Manual smoke — typing 'mitm' shows AITM with badge "Matched via alias 'mitm'"; no inline scripts/styles; tests pass.