### PR TITLE
test(search): E2E alias badge renders matched token

### DIFF
--- a/tests/e2e/alias-badge.spec.ts
+++ b/tests/e2e/alias-badge.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Alias badge shows matched token', () => {
+  test("renders “Matched via alias '<token>'” for common aliases", async ({ page }) => {
+    await page.goto('/');
+    // Wait for client index ready if available, else continue (fallback mode will still work)
+    try {
+      await page.waitForFunction(() => (window as any).__synacIndexReady === true, undefined, {
+        timeout: 15000,
+      });
+    } catch {}
+
+    const q = page.locator('#q');
+    await expect(q).toBeVisible();
+
+    const waitForAnyResult = async () => {
+      await expect
+        .poll(async () => await page.locator('#results .result-item').count(), { timeout: 15000 })
+        .toBeGreaterThan(0);
+    };
+
+    const assertAlias = async (query: string, expectedSlug: string) => {
+      await q.fill('');
+      await q.type(query, { delay: 15 });
+      await waitForAnyResult();
+
+      // Robust selectors per current markup:
+      // .result-item > a.result-link[href^="/terms/"] with a .result-title containing the alias badge
+      const target = page
+        .locator(`.result-item > a.result-link[href="/terms/${expectedSlug}"]`)
+        .first();
+      await expect(target).toBeVisible({ timeout: 15000 });
+      const title = target.locator('.result-title');
+      await expect(title).toContainText(`Matched via alias '${query}'`, { timeout: 15000 });
+    };
+
+    // mitm → AITM
+    await assertAlias('mitm', 'aitm');
+
+    // jot → JWT
+    await assertAlias('jot', 'jwt');
+
+    // ssl → TLS
+    await assertAlias('ssl', 'tls');
+  });
+});


### PR DESCRIPTION
Adds a focused Playwright E2E spec to verify alias badge displays the actual matched alias token.

Changes:
- New spec: [tests/e2e/alias-badge.spec.ts](tests/e2e/alias-badge.spec.ts)
  - Visits '/'; waits for window.__synacIndexReady or #results.
  - Types 'mitm' and asserts result linking to /terms/aitm with title containing “Matched via alias 'mitm'”.
  - Clears, types 'jot' and asserts /terms/jwt with “Matched via alias 'jot'”.
  - Clears, types 'ssl' and asserts /terms/tls with “Matched via alias 'ssl'”.

Selectors used:
- Input: #q
- Results list: #results
- Each item: .result-item > a.result-link[href^="/terms/"]
- Title container: .result-title

Determinism:
- Waits for window.__synacIndexReady if available; otherwise waits for first result item.
- Uses expect(...).toContainText with timeouts; avoids brittle ordering assumptions.

Validation:
- Playwright spec passes locally; typed 'mitm', 'jot', 'ssl' show expected alias badge text; no runtime code changes.